### PR TITLE
Chris order menus; clang-format

### DIFF
--- a/src-juce/AWConsolidatedEditor.cpp
+++ b/src-juce/AWConsolidatedEditor.cpp
@@ -17,7 +17,7 @@ struct AWLookAndFeel : public juce::LookAndFeel_V4
         setColour(juce::PopupMenu::textColourId, juce::Colours::white);
         setColour(juce::PopupMenu::highlightedBackgroundColourId, juce::Colour(60, 60, 65));
         setColour(juce::PopupMenu::highlightedTextColourId, juce::Colours::white);
-        setColour(juce::ScrollBar::ColourIds::thumbColourId, juce::Colour(120,120,125));
+        setColour(juce::ScrollBar::ColourIds::thumbColourId, juce::Colour(120, 120, 125));
 
         auto fs = awres::get_filesystem();
         if (fs.is_file("res/PlusJakartaSans-Medium.ttf"))
@@ -206,7 +206,8 @@ struct DocPanel : juce::Component
 {
     AWConsolidatedAudioProcessorEditor *editor{nullptr};
     DocPanel(AWConsolidatedAudioProcessorEditor *ed) : editor(ed) {}
-    void rebuild() {
+    void rebuild()
+    {
         auto r = juce::Rectangle<int>(0, 0, targetWidth, 10000);
 
         auto tFont = juce::Font(editor->jakartaSansSemi).withHeight(18);
@@ -219,13 +220,12 @@ struct DocPanel : juce::Component
 
         auto bFont = juce::Font(editor->jakartaSansSemi).withHeight(13);
         juce::GlyphArrangement gaBody;
-        gaBody.addFittedText(bFont, editor->docString.trim(), q.getX(), q.getY(),
-                              q.getWidth(), q.getHeight(), juce::Justification::topLeft, 1000);
+        gaBody.addFittedText(bFont, editor->docString.trim(), q.getX(), q.getY(), q.getWidth(),
+                             q.getHeight(), juce::Justification::topLeft, 1000);
         auto bodyBounds = gaBody.getBoundingBox(0, -1, true);
         r = r.withHeight(bodyBounds.getBottom());
 
         setSize(r.getWidth(), r.getHeight());
-
     }
 
     float targetWidth{10};
@@ -251,8 +251,8 @@ struct DocPanel : juce::Component
         auto q = r;
         auto bFont = juce::Font(editor->jakartaSansMedium).withHeight(13);
         juce::GlyphArrangement gaBody;
-        gaBody.addFittedText(bFont, editor->docString.trim(), q.getX(), q.getY(),
-                             q.getWidth(), q.getHeight(), juce::Justification::topLeft, 1000);
+        gaBody.addFittedText(bFont, editor->docString.trim(), q.getX(), q.getY(), q.getWidth(),
+                             q.getHeight(), juce::Justification::topLeft, 1000);
         gaBody.draw(g);
     }
 };
@@ -278,8 +278,8 @@ struct ParamKnob : juce::Component
         auto knobHandle = getLocalBounds().reduced(4).toFloat();
         if (!active)
         {
-            //g.setColour(juce::Colours::grey.withAlpha(0.3f));
-            //g.fillEllipse(knobHandle.toFloat());
+            // g.setColour(juce::Colours::grey.withAlpha(0.3f));
+            // g.fillEllipse(knobHandle.toFloat());
             return;
         }
 
@@ -359,12 +359,12 @@ struct ParamDisp : juce::Component
 
                 g.setColour(juce::Colours::white);
                 g.setFont(juce::Font(editor->jakartaSansSemi).withHeight(20));
-                g.drawText("No Parameters",b, juce::Justification::centredTop);
+                g.drawText("No Parameters", b, juce::Justification::centredTop);
             }
-            //g.setColour(juce::Colours::black.withAlpha(0.1f));
-            //g.fillRoundedRectangle(getLocalBounds().toFloat(), 3);
-            //g.setColour(juce::Colours::white.withAlpha(0.2f));
-            //g.drawRoundedRectangle(getLocalBounds().toFloat(), 3, 1);
+            // g.setColour(juce::Colours::black.withAlpha(0.1f));
+            // g.fillRoundedRectangle(getLocalBounds().toFloat(), 3);
+            // g.setColour(juce::Colours::white.withAlpha(0.2f));
+            // g.drawRoundedRectangle(getLocalBounds().toFloat(), 3, 1);
             return;
         }
         g.setColour(juce::Colours::black);
@@ -392,7 +392,6 @@ AWConsolidatedAudioProcessorEditor::AWConsolidatedAudioProcessorEditor(
     setFocusContainerType(juce::Component::FocusContainerType::keyboardFocusContainer);
 
     setSize(baseHeight, baseHeight);
-
 
     auto fs = awres::get_filesystem();
     try
@@ -455,10 +454,11 @@ AWConsolidatedAudioProcessorEditor::AWConsolidatedAudioProcessorEditor(
     }
 
     auto da = std::make_unique<DocPanel>(this);
-    auto db = getLocalBounds().withTrimmedLeft(margin * 3 + sz + 180)
-              .withTrimmedRight(margin * 2)
-              .withTrimmedTop(60 + 2 * margin)
-              .withTrimmedBottom(40 + margin);
+    auto db = getLocalBounds()
+                  .withTrimmedLeft(margin * 3 + sz + 180)
+                  .withTrimmedRight(margin * 2)
+                  .withTrimmedTop(60 + 2 * margin)
+                  .withTrimmedBottom(40 + margin);
 
     da->targetWidth = db.getWidth() - 10;
     da->rebuild();
@@ -468,6 +468,13 @@ AWConsolidatedAudioProcessorEditor::AWConsolidatedAudioProcessorEditor(
     docView->setBounds(db);
     docView->setViewedComponent(docArea.get(), false);
     addAndMakeVisible(*docView);
+
+    juce::PropertiesFile::Options options;
+    options.applicationName = "AirwindowsConsolidated";
+    options.folderName = "AirwindowsConsolidated";
+    options.filenameSuffix = "settings";
+    options.osxLibrarySubFolder = "Preferences";
+    properties = std::make_unique<juce::PropertiesFile>(options);
 }
 
 AWConsolidatedAudioProcessorEditor::~AWConsolidatedAudioProcessorEditor()
@@ -531,14 +538,18 @@ void AWConsolidatedAudioProcessorEditor::jog(int dir)
 
 void AWConsolidatedAudioProcessorEditor::showMenu()
 {
-    // auto nx = AirwinRegistry::neighborIndexFor(processor.curentProcessorIndex, 1);
-    //  processor.pushResetTypeFromUI(nx);
     auto p = juce::PopupMenu();
     auto ent = AirwinRegistry::registry[processor.curentProcessorIndex];
 
-    p.addSectionHeader("Airwindows Effect");
+    p.addSectionHeader("Airwindows Consolidated");
     p.addSeparator();
-    for (const auto &[cat, set] : AirwinRegistry::fxByCategory)
+    const auto *order = &AirwinRegistry::fxByCategory;
+
+    bool isChrisOrder = properties->getValue("ordering") == "chris";
+    if (isChrisOrder)
+        order = &AirwinRegistry::fxByCategoryChrisOrder;
+
+    for (const auto &[cat, set] : *order)
     {
         juce::PopupMenu sub;
         for (const auto &nm : set)
@@ -550,6 +561,26 @@ void AWConsolidatedAudioProcessorEditor::showMenu()
         }
         p.addSubMenu(cat, sub, true, nullptr, cat == ent.category);
     }
+
+    p.addSeparator();
+
+    auto settingsMenu = juce::PopupMenu();
+    settingsMenu.addItem("Alphabetical Order Menus", true, !isChrisOrder,
+                         [w = juce::Component::SafePointer(this)]() {
+                             if (w)
+                             {
+                                 w->properties->setValue("ordering", "alpha");
+                             }
+                         });
+    settingsMenu.addItem("Chris (Quality) Order Menus", true, isChrisOrder,
+                         [w = juce::Component::SafePointer(this)]() {
+                             if (w)
+                             {
+                                 w->properties->setValue("ordering", "chris");
+                             }
+                         });
+
+    p.addSubMenu("Settings", settingsMenu);
 
     p.showMenuAsync(juce::PopupMenu::Options().withParentComponent(this));
 }

--- a/src-juce/AWConsolidatedEditor.h
+++ b/src-juce/AWConsolidatedEditor.h
@@ -14,7 +14,6 @@ class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor, ju
     AWConsolidatedAudioProcessorEditor(AWConsolidatedAudioProcessor &);
     ~AWConsolidatedAudioProcessorEditor();
 
-
     //==============================================================================
     void paint(juce::Graphics &) override;
     void resized() override;
@@ -53,6 +52,7 @@ class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor, ju
     juce::Typeface::Ptr jakartaSansMedium, jakartaSansSemi, firaMono;
 
     std::unique_ptr<juce::LookAndFeel_V4> lnf;
+    std::unique_ptr<juce::PropertiesFile> properties;
 
     // debugging
     int gv{0}, bv{0};

--- a/src-juce/AWConsolidatedProcessor.cpp
+++ b/src-juce/AWConsolidatedProcessor.cpp
@@ -41,8 +41,8 @@ AWConsolidatedAudioProcessor::AWConsolidatedAudioProcessor()
     // Multiple calls to addParameter here
     for (int i = 0; i < nAWParams; ++i)
     {
-        fxParams[i] = new AWParam(juce::ParameterID(std::string("ctrl_") + std::to_string(i), 1), "Name",
-                                  juce::NormalisableRange<float>(0.f, 1.f), 0.f);
+        fxParams[i] = new AWParam(juce::ParameterID(std::string("ctrl_") + std::to_string(i), 1),
+                                  "Name", juce::NormalisableRange<float>(0.f, 1.f), 0.f);
         fxParams[i]->getTextHandler = [i, this](auto f, auto iv) {
             std::lock_guard<std::mutex> g(this->displayProcessorMutex);
             if (this->awDisplayProcessor && i < this->nProcessorParams)
@@ -54,7 +54,7 @@ AWConsolidatedAudioProcessor::AWConsolidatedAudioProcessor()
                 char tl[kVstMaxParamStrLen], td[kVstMaxParamStrLen];
                 this->awDisplayProcessor->getParameterDisplay(i, td);
                 this->awDisplayProcessor->getParameterLabel(i, tl);
-                return std::string(td) + (tl[0] == 0 ? "" : " " ) + std::string(tl);
+                return std::string(td) + (tl[0] == 0 ? "" : " ") + std::string(tl);
             }
             else
             {
@@ -66,7 +66,8 @@ AWConsolidatedAudioProcessor::AWConsolidatedAudioProcessor()
             if (this->awDisplayProcessor && i < this->nProcessorParams)
             {
                 float rv = 0.f;
-                auto res = this->awDisplayProcessor->parameterTextToValue(i, s.toStdString().c_str(), rv);
+                auto res =
+                    this->awDisplayProcessor->parameterTextToValue(i, s.toStdString().c_str(), rv);
                 if (res)
                     return rv;
             }
@@ -118,10 +119,7 @@ void AWConsolidatedAudioProcessor::prepareToPlay(double sr, int samplesPerBlock)
     isPlaying = true;
 }
 
-void AWConsolidatedAudioProcessor::releaseResources()
-{
-    isPlaying = false;
-}
+void AWConsolidatedAudioProcessor::releaseResources() { isPlaying = false; }
 
 bool AWConsolidatedAudioProcessor::isBusesLayoutSupported(const BusesLayout &layouts) const
 {
@@ -156,19 +154,18 @@ void AWConsolidatedAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer
     auto inBus = getBus(true, 0);
     auto outBus = getBus(false, 0);
 
-    if (inBus->getNumberOfChannels() == 0 ||
-        outBus->getNumberOfChannels() != 2 ||
+    if (inBus->getNumberOfChannels() == 0 || outBus->getNumberOfChannels() != 2 ||
         buffer.getNumChannels() < 2)
     {
         isPlaying = false;
         return;
     }
 
-
     const float *inputs[2];
     float *outputs[2];
     inputs[0] = buffer.getReadPointer(0);
-    inputs[1] = inBus->getNumberOfChannels() == 2 ? buffer.getReadPointer(1) : buffer.getReadPointer(0);
+    inputs[1] =
+        inBus->getNumberOfChannels() == 2 ? buffer.getReadPointer(1) : buffer.getReadPointer(0);
     outputs[0] = buffer.getWritePointer(0);
     outputs[1] = buffer.getWritePointer(1);
 
@@ -185,9 +182,7 @@ void AWConsolidatedAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer
         awProcessor->setParameter(i, fxParams[i]->get());
     }
 
-    awProcessor->processReplacing((float **)inputs,
-                                  (float **)outputs,
-                                  buffer.getNumSamples());
+    awProcessor->processReplacing((float **)inputs, (float **)outputs, buffer.getNumSamples());
 }
 
 //==============================================================================
@@ -274,13 +269,13 @@ void AWConsolidatedAudioProcessor::setStateInformation(const void *data, int siz
             auto streamingVersion = xmlState->getIntAttribute("streamingVersion", (int)2);
             auto effectName = xmlState->getStringAttribute("currentProcessorName");
 
-            if (AirwinRegistry::nameToIndex.find(effectName.toStdString())
-                != AirwinRegistry::nameToIndex.end())
+            if (AirwinRegistry::nameToIndex.find(effectName.toStdString()) !=
+                AirwinRegistry::nameToIndex.end())
             {
                 setAWProcessorTo(AirwinRegistry::nameToIndex.at(effectName.toStdString()), true);
             }
 
-            for (int i=0; i<nAWParams; ++i)
+            for (int i = 0; i < nAWParams; ++i)
             {
                 juce::String nm = juce::String("awp_") + std::to_string(i);
                 auto f = xmlState->getDoubleAttribute(nm);

--- a/src-juce/AWConsolidatedProcessor.h
+++ b/src-juce/AWConsolidatedProcessor.h
@@ -9,16 +9,12 @@
 #include <execinfo.h>
 #endif
 
-template <typename T, int Capacity=4096>
-class LockFreeQueue
+template <typename T, int Capacity = 4096> class LockFreeQueue
 {
   public:
-    LockFreeQueue()
-        : fifo(Capacity)
-    {
-    }
+    LockFreeQueue() : fifo(Capacity) {}
 
-    void push(const T& item)
+    void push(const T &item)
     {
         int start1, size1, start2, size2;
         fifo.prepareToWrite(1, start1, size1, start2, size2);
@@ -31,7 +27,7 @@ class LockFreeQueue
         fifo.finishedWrite(size1);
     }
 
-    bool pop(T& item)
+    bool pop(T &item)
     {
         int start1, size1, start2, size2;
         fifo.prepareToRead(1, start1, size1, start2, size2);
@@ -55,11 +51,10 @@ class LockFreeQueue
 /**
  */
 class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
-                              public juce::AudioProcessorParameter::Listener,
-                              public juce::AsyncUpdater
+                                     public juce::AudioProcessorParameter::Listener,
+                                     public juce::AsyncUpdater
 {
   public:
-
     static constexpr int nAWParams{10};
 
     //==============================================================================
@@ -138,7 +133,6 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
         {
         }
 
-
         juce::String getName(int end) const override { return mutableName.substring(0, end); }
 
         std::function<juce::String(float, int)> getTextHandler{nullptr};
@@ -163,8 +157,6 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
     std::mutex displayProcessorMutex;
     int nProcessorParams{0};
     std::atomic<int> curentProcessorIndex{0};
-
-
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AWConsolidatedAudioProcessor)
 };

--- a/src/AirwinRegistry.cpp
+++ b/src/AirwinRegistry.cpp
@@ -15,7 +15,8 @@ CMRC_DECLARE(awdoc_resources);
 std::vector<AirwinRegistry::awReg> AirwinRegistry::registry;
 std::set<std::string> AirwinRegistry::categories;
 std::vector<int> AirwinRegistry::fxAlphaOrdering;
-std::map<std::string, std::set<std::string>> AirwinRegistry::fxByCategory;
+std::map<std::string, std::vector<std::string>> AirwinRegistry::fxByCategory;
+std::map<std::string, std::vector<std::string>> AirwinRegistry::fxByCategoryChrisOrder;
 std::unordered_map<std::string, int> AirwinRegistry::nameToIndex;
 
 std::string AirwinRegistry::documentationStringFor(int index)

--- a/src/AirwinRegistry.h
+++ b/src/AirwinRegistry.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <iostream>
 #include <functional>
+#include <algorithm>
 
 #include "airwin2rackbase.h"
 

--- a/src/AirwinRegistry.h
+++ b/src/AirwinRegistry.h
@@ -35,7 +35,8 @@ struct AirwinRegistry
     };
     static std::vector<awReg> registry;
     static std::set<std::string> categories;
-    static std::map<std::string, std::set<std::string>> fxByCategory;
+    static std::map<std::string, std::vector<std::string>> fxByCategory;
+    static std::map<std::string, std::vector<std::string>> fxByCategoryChrisOrder;
     static std::vector<int> fxAlphaOrdering;
     static std::unordered_map<std::string, int> nameToIndex;
 
@@ -70,8 +71,15 @@ struct AirwinRegistry
         {
             nameToIndex[r.name] = idx;
             categories.insert(r.category);
-            fxByCategory[r.category].insert(r.name);
+            fxByCategory[r.category].push_back(r.name);
+            fxByCategoryChrisOrder[r.category].push_back(r.name);
             idx++;
+        }
+
+        for (auto &[cat, dat] : fxByCategory)
+        {
+            std::sort(dat.begin(), dat.end(), [](const auto &a,
+                                                 const auto &b) { return a > b; });
         }
 
         idx = 0;
@@ -83,6 +91,18 @@ struct AirwinRegistry
                 fxAlphaOrdering.push_back(nameToIndex[fx]);
                 idx++;
             }
+        }
+
+
+        for (auto &[cat, dat] : fxByCategoryChrisOrder)
+        {
+            std::sort(dat.begin(), dat.end(), [](const auto &a,
+                                                 const auto &b) {
+                // this double lookup is a bit of a bummer
+                auto ai = AirwinRegistry::nameToIndex[a];
+                auto bi = AirwinRegistry::nameToIndex[b];
+                return AirwinRegistry::registry[ai].catChrisOrdering < AirwinRegistry::registry[bi].catChrisOrdering;
+            });
         }
 
         return 0;


### PR DESCRIPTION
1. Menus can be in Chris order in JUCE
2. Juce gets a properties bundle
3. clang-format the code