### PR TITLE
Accessibility three: Turn the documentation into a TextEd

### DIFF
--- a/src-juce/AWConsolidatedEditor.h
+++ b/src-juce/AWConsolidatedEditor.h
@@ -48,7 +48,6 @@ class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor, ju
     std::unique_ptr<juce::Component> awTag;
 
     std::unique_ptr<DocPanel> docArea;
-    std::unique_ptr<juce::Viewport> docView;
 
     juce::String docString, docHeader;
 


### PR DESCRIPTION
This has better ally bindings, and also made the UI code for signted UI quite a bit easier and cleaner!