### PR TITLE
Typein Support

### DIFF
--- a/doc/manualdaw.md
+++ b/doc/manualdaw.md
@@ -38,7 +38,10 @@ allows you to type a partial plugin or category name and see a set of matching
 effects with their documentation to select.
 
 The parameters display the current value and parameter name with a knob to
-edit the value. Shift allows slower knob drags.
+edit the value. Shift allows slower knob drags. If you click on the value, 
+a text editor appears allowing you to type in a value. For a very small
+number of parameters, text entry isn't supported; in these cases no editor
+will appear on click.
 
 The documentation section displays the description of the effect which Chris
 wrote on launch day in a scrollable area.
@@ -60,6 +63,9 @@ menu and select a collection you want. "All plugins" choice removes any filterin
 The User Interface is exposed via a Screen Reader on macOS and Windows.
 Tab moves between elements, as expected. On the controls the arrow keys
 change values, with shift depressed change values in a smaller increment.
+On a given knob, Shift-F10 will activate the typein area allowing you to
+key in a value. As noted above, a small number of parameters do not support
+text-to-value; for those Shift-F10 will do nothing.
 
 The documentation region by default is a read-only label, but many screen
 readers present large labels poorly. For Screen Reader users we recommend

--- a/src-juce/AWConsolidatedEditor.h
+++ b/src-juce/AWConsolidatedEditor.h
@@ -9,6 +9,7 @@
  */
 struct DocPanel;
 struct ParamKnob;
+struct ParamDisp;
 struct Picker;
 class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor, juce::AsyncUpdater
 {
@@ -26,7 +27,8 @@ class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor, ju
     void showMenu();
     void jog(int dir);
 
-    std::string getCurrentCollection() {
+    std::string getCurrentCollection()
+    {
         return properties->getValue("collection", "Recommended").toStdString();
     }
     void setCurrentCollection(const std::string &s)
@@ -52,7 +54,7 @@ class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor, ju
     std::unique_ptr<IdleTimer> idleTimer;
     std::unique_ptr<Picker> menuPicker;
     std::array<std::unique_ptr<ParamKnob>, AWConsolidatedAudioProcessor::nAWParams> knobs;
-    std::array<std::unique_ptr<juce::Component>, AWConsolidatedAudioProcessor::nAWParams> labels;
+    std::array<std::unique_ptr<ParamDisp>, AWConsolidatedAudioProcessor::nAWParams> labels;
 
     std::unique_ptr<juce::Drawable> clipperIcon;
     std::unique_ptr<juce::Component> awTag;

--- a/src-juce/AWConsolidatedProcessor.cpp
+++ b/src-juce/AWConsolidatedProcessor.cpp
@@ -73,10 +73,7 @@ AWConsolidatedAudioProcessor::AWConsolidatedAudioProcessor()
             }
             return this->fxParams[i]->get();
         };
-        fxParams[i]->getDefaultValueHandler = [i, this]()
-        {
-            return this->defaultValues[i];
-        };
+        fxParams[i]->getDefaultValueHandler = [i, this]() { return this->defaultValues[i]; };
         fxParams[i]->addListener(this);
         addParameter(fxParams[i]);
     }
@@ -97,12 +94,10 @@ bool AWConsolidatedAudioProcessor::isMidiEffect() const { return false; }
 
 double AWConsolidatedAudioProcessor::getTailLengthSeconds() const { return 2.0; }
 
-int AWConsolidatedAudioProcessor::getNumPrograms()
-{
-    return AirwinRegistry::registry.size();
-}
+int AWConsolidatedAudioProcessor::getNumPrograms() { return AirwinRegistry::registry.size(); }
 
-int AWConsolidatedAudioProcessor::getCurrentProgram() {
+int AWConsolidatedAudioProcessor::getCurrentProgram()
+{
     // not super efficient obvs
     int idx{0};
     for (auto &i : AirwinRegistry::fxAlphaOrdering)
@@ -114,7 +109,8 @@ int AWConsolidatedAudioProcessor::getCurrentProgram() {
     return 0;
 }
 
-void AWConsolidatedAudioProcessor::setCurrentProgram(int index) {
+void AWConsolidatedAudioProcessor::setCurrentProgram(int index)
+{
     auto rs = AirwinRegistry::fxAlphaOrdering[index];
     pushResetTypeFromUI(rs);
 }

--- a/src-juce/AWConsolidatedProcessor.h
+++ b/src-juce/AWConsolidatedProcessor.h
@@ -146,7 +146,8 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
         }
 
         std::function<float()> getDefaultValueHandler{nullptr};
-        float getDefaultValue() const override {
+        float getDefaultValue() const override
+        {
             if (getDefaultValueHandler)
                 return getDefaultValueHandler();
             return 0;


### PR DESCRIPTION
- Click to edit a value if supported
- Shift-F10 in screen reader, with focus returned to the right spot