### PR TITLE
Fix the Linux settings location

### DIFF
--- a/src-juce/AWConsolidatedEditor.cpp
+++ b/src-juce/AWConsolidatedEditor.cpp
@@ -1133,7 +1133,12 @@ AWConsolidatedAudioProcessorEditor::AWConsolidatedAudioProcessorEditor(
 
     juce::PropertiesFile::Options options;
     options.applicationName = "AirwindowsConsolidated";
+#if JUCE_LINUX
+    options.folderName = ".config/AirwindowsConsolidated";
+#else
     options.folderName = "AirwindowsConsolidated";
+#endif
+
     options.filenameSuffix = "settings";
     options.osxLibrarySubFolder = "Preferences";
     properties = std::make_unique<juce::PropertiesFile>(options);


### PR DESCRIPTION
juce::PropertiesFile::Options::getDefaultFile makes a bad choice on linux of just dumping into home dir, so if JUCE_LINUX is true set the properties file directory to ".config/AirwindowsConsolidated" which works.

Closes #72