### PR TITLE
Modify our UI display vs Processor strategy

### DIFF
--- a/src-juce/AWConsolidatedProcessor.h
+++ b/src-juce/AWConsolidatedProcessor.h
@@ -114,8 +114,11 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
             awDisplayProcessor = rg.generator();
             awDisplayProcessor->setSampleRate(getSampleRate());
         }
+        setupParamDisplaysFromDisplayProcessor(index);
+
         if (isPlaying)
         {
+            curentProcessorIndex = index;
             resetType.push({-1, index, 0.f});
         }
         else
@@ -123,6 +126,8 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
             setAWProcessorTo(index, false);
         }
     }
+    void setupParamDisplaysFromDisplayProcessor(int index);
+
     std::atomic<bool> refreshUI{false},
         rebuildUI{false}; // repaint vs re-setup everything. Value vs type
 


### PR DESCRIPTION
Use the display processor copy for more things in the UI and the audio thread one for less. This means that problems with not switching whtn the UI thread is in various uncalled states are all fixed, it seems.