### PR TITLE
Work around a Renoise Re-Entrant Param Difference

### DIFF
--- a/src-juce/AWConsolidatedEditor.cpp
+++ b/src-juce/AWConsolidatedEditor.cpp
@@ -687,7 +687,7 @@ struct ParamDisp : juce::Component, juce::TextEditor::Listener
     {
         bool go{false};
         {
-            std::lock_guard<std::mutex> g(editor->processor.displayProcessorMutex);
+            LOCK(editor->processor.displayProcessorMutex);
             go = editor->processor.awDisplayProcessor->canConvertParameterTextToValue(index);
         }
 
@@ -723,7 +723,7 @@ struct ParamDisp : juce::Component, juce::TextEditor::Listener
             float f{0};
             bool worked{false};
             {
-                std::lock_guard<std::mutex> g(editor->processor.displayProcessorMutex);
+                LOCK(editor->processor.displayProcessorMutex);
                 worked = editor->processor.awDisplayProcessor->parameterTextToValue(
                     index, ed.getText().toRawUTF8(), f);
             }


### PR DESCRIPTION
https://forum.renoise.com/t/macos-crash-with-airwindows-vst-when-changing-presets/72288/9

Renoise re-enters get during set notifying, and no other daw does, but that deadlocked me. So move my sets outside my setup.

Closes #87