### PR TITLE
Startup Effect Property; Move Properties on macOS

### DIFF
--- a/src-juce/AWConsolidatedEditor.h
+++ b/src-juce/AWConsolidatedEditor.h
@@ -124,11 +124,11 @@ class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor,
 
     std::string getCurrentCollection()
     {
-        return properties->getValue("collection", "Recommended").toStdString();
+        return processor.properties->getValue("collection", "Recommended").toStdString();
     }
     void setCurrentCollection(const std::string &s)
     {
-        properties->setValue("collection", juce::String(s));
+        processor.properties->setValue("collection", juce::String(s));
     }
     std::string allCollection{"All"};
 
@@ -168,7 +168,6 @@ class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor,
     juce::String docString, docHeader;
 
     std::unique_ptr<AWLookAndFeel> lnf;
-    std::unique_ptr<juce::PropertiesFile> properties;
 
     std::vector<juce::Component *> accessibleOrderWeakRefs;
     std::unique_ptr<juce::ComponentTraverser> createKeyboardFocusTraverser() override;

--- a/src-juce/AWConsolidatedProcessor.cpp
+++ b/src-juce/AWConsolidatedProcessor.cpp
@@ -58,7 +58,23 @@ AWConsolidatedAudioProcessor::AWConsolidatedAudioProcessor()
         addParameter(fxParams[i]);
     }
 
-    setAWProcessorTo(AirwinRegistry::nameToIndex.at("Galactic"), true);
+    juce::PropertiesFile::Options options;
+    options.applicationName = "AirwindowsConsolidated";
+#if JUCE_LINUX
+    options.folderName = ".config/AirwindowsConsolidated";
+#else
+    options.folderName = "AirwindowsConsolidated";
+#endif
+
+    options.filenameSuffix = "settings";
+    options.osxLibrarySubFolder = "Application Support";
+    properties = std::make_unique<juce::PropertiesFile>(options);
+
+    auto defaultName = properties->getValue("startupEffect", "Galactic").toStdString();
+    if (AirwinRegistry::nameToIndex.find(defaultName) == AirwinRegistry::nameToIndex.end())
+        defaultName = "Galactic";
+
+    setAWProcessorTo(AirwinRegistry::nameToIndex.at(defaultName), true);
 }
 
 AWConsolidatedAudioProcessor::~AWConsolidatedAudioProcessor() {}

--- a/src-juce/AWConsolidatedProcessor.h
+++ b/src-juce/AWConsolidatedProcessor.h
@@ -197,6 +197,8 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
     int nProcessorParams{0};
     std::atomic<int> curentProcessorIndex{0};
 
+    std::unique_ptr<juce::PropertiesFile> properties;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AWConsolidatedAudioProcessor)
 };
 


### PR DESCRIPTION
- The default startup property is Galactic. Allow users to overdide this as a sticky preference. Closes #93
- While at it, fix the macos preferences file location.