### PR TITLE
When doing 'text-for' make sure to use the value

### DIFF
--- a/src-juce/AWConsolidatedProcessor.cpp
+++ b/src-juce/AWConsolidatedProcessor.cpp
@@ -31,6 +31,7 @@ AWConsolidatedAudioProcessor::AWConsolidatedAudioProcessor()
                 {
                     awDisplayProcessor->setParameter(id, fxParams[id]->get());
                 }
+                awDisplayProcessor->setParameter(i, f);
                 char tl[kVstMaxParamStrLen], td[kVstMaxParamStrLen];
                 this->awDisplayProcessor->getParameterDisplay(i, td);
                 this->awDisplayProcessor->getParameterLabel(i, tl);

--- a/src-juce/AWConsolidatedProcessor.h
+++ b/src-juce/AWConsolidatedProcessor.h
@@ -168,7 +168,11 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
 
         std::function<juce::String(float, int)> getTextHandler{nullptr};
         std::function<float(const juce::String &)> getTextToValue{nullptr};
-        juce::String getText(float f, int i) const override { return getTextHandler(f, i); }
+        juce::String getText(float f, int i) const override {
+            if (getTextHandler)
+                return getTextHandler(f, i);
+            return std::to_string(f);
+        }
 
         float getValueForText(const juce::String &text) const override
         {


### PR DESCRIPTION
The 'text-for' display processor used the current values but not the handed ones. Duh! This will fix a few random bugs we've heard about I'm sure, but definitely fixes #94