### PR TITLE
Have tab traversal work with doc off

### DIFF
--- a/src-juce/AWConsolidatedEditor.cpp
+++ b/src-juce/AWConsolidatedEditor.cpp
@@ -1922,13 +1922,18 @@ struct FxFocusTrav : public juce::ComponentTraverser
             return nullptr;
         }
 
+        auto isAccessibleAndVisible = [](auto *r)
+        {
+            return r->isAccessible() && r->isVisible();
+        };
+
         switch (dir)
         {
         case 1:
         {
             auto res = std::next(iter);
 
-            while (res != editor->accessibleOrderWeakRefs.cend() && !(*res)->isAccessible())
+            while (res != editor->accessibleOrderWeakRefs.cend() && !isAccessibleAndVisible(*res))
             {
                 res = std::next(res);
             }
@@ -1943,7 +1948,7 @@ struct FxFocusTrav : public juce::ComponentTraverser
             auto res = iter;
 
             while (res != editor->accessibleOrderWeakRefs.cbegin() &&
-                   !(*std::prev(res))->isAccessible())
+                   !isAccessibleAndVisible(*std::prev(res)))
             {
                 res = std::prev(res);
             }


### PR DESCRIPTION
Tab traverser happily walked into an invisible component if it was accessible, which with doc hidden we sort of have.

So don't do that.

Closes #128