### PR TITLE
Loading of custom docs from txt files

### DIFF
--- a/src-juce/AWConsolidatedEditor.cpp
+++ b/src-juce/AWConsolidatedEditor.cpp
@@ -1652,7 +1652,6 @@ void AWConsolidatedAudioProcessorEditor::resizeDocArea()
 
     // Load custom manual
     juce::String customDocumentationContent;
-    // juce::String processorName = AirwinRegistry::registry[processor.curentProcessorIndex].name;
     if (loadCustomDocumentation(AirwinRegistry::registry[processor.curentProcessorIndex].name, customDocumentationContent))
     {
         if (!customDocumentationContent.isEmpty())

--- a/src-juce/AWConsolidatedEditor.cpp
+++ b/src-juce/AWConsolidatedEditor.cpp
@@ -2345,7 +2345,7 @@ void AWConsolidatedAudioProcessorEditor::unstreamFavorites()
 juce::File AWConsolidatedAudioProcessorEditor::getSettingsDirectory(bool makeDir) const
 {
     juce::File res;
-    
+
 #if JUCE_LINUX
     res = juce::File::getSpecialLocation(juce::File::userHomeDirectory);
     res = res.getChildFile(".Airwindows");

--- a/src-juce/AWConsolidatedEditor.h
+++ b/src-juce/AWConsolidatedEditor.h
@@ -193,7 +193,7 @@ class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor,
     void unstreamFavorites();
     juce::File getSettingsDirectory(bool makeDir) const;
     juce::File getFavoritesFile(bool makeDir) const;
-    bool AWConsolidatedAudioProcessorEditor::loadCustomDocumentation(const juce::String& fileName, juce::String& outContent) const;
+    bool loadCustomDocumentation(const juce::String& fileName, juce::String& outContent) const;
     std::set<std::string> favoritesList{};
 
   private:

--- a/src-juce/AWConsolidatedEditor.h
+++ b/src-juce/AWConsolidatedEditor.h
@@ -191,7 +191,9 @@ class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor,
     void removeCurrentAsFavorite();
     void streamFavorites();
     void unstreamFavorites();
+    juce::File getSettingsDirectory(bool makeDir) const;
     juce::File getFavoritesFile(bool makeDir) const;
+    bool AWConsolidatedAudioProcessorEditor::loadCustomDocumentation(const juce::String& fileName, juce::String& outContent) const;
     std::set<std::string> favoritesList{};
 
   private:


### PR DESCRIPTION
# Feature: Adds the ability to load custom documentation for effects.

- Looks for documentation file \<settingsDir\>/customDocs/\<plugin-name\>.txt
- If custom documentation exists, it is prepended to the standard documentation with a separator.
- The last loaded custom documentation is cached to avoid repeated file reads on calls to resizeDocArea()

(settingsDir is the same dir where favorites are stored)

Code changes:

- Added loadCustomDocumentation() to handle reading and caching documentation.
- Updated resizeDocArea() to include custom documentation if available.
- Move directory stuff from getFavoritesFile(), into its own getSettingsDirectory(), for reuse in loadCustomDocumentation()