### PR TITLE
Handle a crash case with corrupted favorites file

### DIFF
--- a/src-juce/AWConsolidatedEditor.cpp
+++ b/src-juce/AWConsolidatedEditor.cpp
@@ -2356,6 +2356,13 @@ void AWConsolidatedAudioProcessorEditor::unstreamFavorites()
     {
         auto xd = juce::XmlDocument(ff);
         auto re = xd.getDocumentElement();
+
+        if (!re)
+        {
+            std::cerr << "Favorites file is corrupted: " << xd.getLastParseError() << std::endl;
+            return;
+        }
+
         for (auto *e : re->getChildIterator())
         {
             auto fn = e->getStringAttribute("fx");


### PR DESCRIPTION
If the favorites file didn't parse I tried to read the parse result anyway, leading to a crash on startup