### PR TITLE
Use juce::AudioBuffer::applyGain to simplify buffer handling

### DIFF
--- a/src-juce/AWConsolidatedProcessor.h
+++ b/src-juce/AWConsolidatedProcessor.h
@@ -285,11 +285,6 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
     int nProcessorParams{0};
     std::atomic<int> curentProcessorIndex{0};
 
-    // We need a place to write the scaled input
-    static constexpr int maxInBlock{1024 * 128}; // that's about 2 seconds at 48k
-    float inputTempBufferF[2][maxInBlock];
-    double inputTempBufferD[2][maxInBlock];
-
     std::unique_ptr<juce::PropertiesFile> properties;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AWConsolidatedAudioProcessor)


### PR DESCRIPTION
Eliminated the need for temporary audio buffers in AWConsolidatedAudioProcessor by utilizing the applyGain() method in juce::AudioBuffer.
It automatically applies the gain to all buffers, simplifying the buffer handling when M->M might be supported.
It also neatly solves a FIXME regarding hardcoded buffer lengths.

If anything needs change just let me know :-)