### PR TITLE
Ensure that no popup menu lingers after editor has been closed

### DIFF
--- a/src-juce/AWConsolidatedEditor.cpp
+++ b/src-juce/AWConsolidatedEditor.cpp
@@ -1554,6 +1554,9 @@ AWConsolidatedAudioProcessorEditor::AWConsolidatedAudioProcessorEditor(
 
 AWConsolidatedAudioProcessorEditor::~AWConsolidatedAudioProcessorEditor()
 {
+    // Ensure that no popup menu lingers after editor has been closed... (Seen with AU plugin in both Logic Pro and Reaper)
+    juce::PopupMenu::dismissAllActiveMenus();
+
     // release any references to the look and feel
     setLookAndFeel(&juce::LookAndFeel::getDefaultLookAndFeel());
 


### PR DESCRIPTION
Just a small bugfix. I have seen this from time to time in Logic Pro, if the plugin editor is closed while either the effect or option popup menu is active, the popup menu would stay.
You had to open the plugin again to get it to disappear.

When I say the same behavior in Reaper, and found a solution.
