### PR TITLE
Presisting the bypass paramter.

### DIFF
--- a/src-juce/AWConsolidatedEditor.cpp
+++ b/src-juce/AWConsolidatedEditor.cpp
@@ -959,6 +959,7 @@ struct BypassButton : public juce::ToggleButton
     {
         setAccessible(true);
         setTitle("Bypass");
+        setToggleState(editor->processor.bypassParam->get(), juce::NotificationType::dontSendNotification);
     }
     void paintButton(juce::Graphics &g, bool shouldDrawButtonAsHighlighted,
                      bool shouldDrawButtonAsDown) override
@@ -1621,7 +1622,6 @@ AWConsolidatedAudioProcessorEditor::AWConsolidatedAudioProcessorEditor(
     docBodyLabel = std::make_unique<DocHeader>(this);
     docBodyLabel->setTitle("Documentation Header");
     addAndMakeVisible(*docBodyLabel);
-
     docBodyEd = std::make_unique<juce::TextEditor>("Documentation");
     docBodyEd->setMultiLine(true);
     docBodyEd->setFont(lnf->lookupFont(documentationBody));

--- a/src-juce/AWConsolidatedProcessor.cpp
+++ b/src-juce/AWConsolidatedProcessor.cpp
@@ -429,6 +429,7 @@ void AWConsolidatedAudioProcessor::getStateInformation(juce::MemoryBlock &destDa
     }
     xml->setAttribute("inlev", inLev->get());
     xml->setAttribute("outlev", outLev->get());
+    xml->setAttribute("bypass", bypassParam->get());
 
     xml->setAttribute("monoBehaviour", monoBehaviourParameter->get());
 
@@ -462,6 +463,9 @@ void AWConsolidatedAudioProcessor::setStateInformation(const void *data, int siz
             inLev->setValueNotifyingHost(il);
             auto ol = xmlState->getDoubleAttribute("outlev", CubicDBParam::defaultVal);
             outLev->setValueNotifyingHost(ol);
+
+            auto bypass = xmlState->getBoolAttribute("bypass", false);
+            bypassParam->setValueNotifyingHost(bypass);
 
             auto mono = xmlState->getIntAttribute("monoBehaviour");
             *monoBehaviourParameter = static_cast<MonoBehaviourParameter::MonoBehaviour>(mono);


### PR DESCRIPTION
Also ensure that the bypass button is created with the correct value.

I was running the validator from the vst3sdk, and saw that it complained that the bypass parameter was not persisted.
So I fixed that, which let me to a different but related issue. In Reaper when bypassing a plugin and switching between different FX's when the bypassed plugin was selected again, the bypass button would always be "non-bypassed". After 10-15 seconds the plugin would automatically un-bypass.
This was the case even before the bypass was persisted.

If it was never the intention to persist the bypass option, please just close this PR. Then I can make a separate one with the Reaper fix if wanted.