### PR TITLE
Lift the 10-constraint in code (but keep it in the clients)

### DIFF
--- a/src-juce/AWConsolidatedEditor.cpp
+++ b/src-juce/AWConsolidatedEditor.cpp
@@ -222,7 +222,6 @@ juce::Font AWLookAndFeel::getPopupMenuFont()
     return AWC_JUCE_FONT_CTOR(jakartaSansMedium).withHeight(16);
 }
 
-
 void AWLookAndFeel::drawPopupMenuBackgroundWithOptions(juce::Graphics &g, int width, int height,
                                                        const juce::PopupMenu::Options &o)
 {
@@ -233,102 +232,106 @@ void AWLookAndFeel::drawPopupMenuBackgroundWithOptions(juce::Graphics &g, int wi
     g.drawRect(0, 0, width, height);
 }
 
-void AWEffectPopupLookAndFeel::drawPopupMenuItem (juce::Graphics& g, const juce::Rectangle<int>& area,
-                                            const bool isSeparator, const bool isActive,
-                                            const bool isHighlighted, const bool isTicked,
-                                            const bool hasSubMenu, const juce::String& text,
-                                            const juce::String& shortcutKeyText,
-                                            const juce::Drawable* icon, const juce::Colour* const textColourToUse)
+void AWEffectPopupLookAndFeel::drawPopupMenuItem(
+    juce::Graphics &g, const juce::Rectangle<int> &area, const bool isSeparator,
+    const bool isActive, const bool isHighlighted, const bool isTicked, const bool hasSubMenu,
+    const juce::String &text, const juce::String &shortcutKeyText, const juce::Drawable *icon,
+    const juce::Colour *const textColourToUse)
 {
     if (isSeparator)
     {
-        auto r  = area.reduced (5, 0);
-        r.removeFromTop (juce::roundToInt (((float) r.getHeight() * 0.5f) - 0.5f));
+        auto r = area.reduced(5, 0);
+        r.removeFromTop(juce::roundToInt(((float)r.getHeight() * 0.5f) - 0.5f));
 
-        g.setColour (findColour (juce::PopupMenu::textColourId).withAlpha (0.3f));
-        g.fillRect (r.removeFromTop (1));
+        g.setColour(findColour(juce::PopupMenu::textColourId).withAlpha(0.3f));
+        g.fillRect(r.removeFromTop(1));
     }
     else
     {
-        auto textColour = (textColourToUse == nullptr ? findColour (juce::PopupMenu::textColourId)
-                                                        : *textColourToUse);
+        auto textColour = (textColourToUse == nullptr ? findColour(juce::PopupMenu::textColourId)
+                                                      : *textColourToUse);
 
-        auto r  = area.reduced (1);
+        auto r = area.reduced(1);
 
         if (isHighlighted && isActive)
         {
-            g.setColour (findColour (juce::PopupMenu::highlightedBackgroundColourId));
-            g.fillRect (r);
+            g.setColour(findColour(juce::PopupMenu::highlightedBackgroundColourId));
+            g.fillRect(r);
 
-            g.setColour (findColour (juce::PopupMenu::highlightedTextColourId));
+            g.setColour(findColour(juce::PopupMenu::highlightedTextColourId));
         }
         else
         {
-            g.setColour (textColour.withMultipliedAlpha (isActive ? 1.0f : 0.5f));
+            g.setColour(textColour.withMultipliedAlpha(isActive ? 1.0f : 0.5f));
         }
 
-        r.reduce (juce::jmin (5, area.getWidth() / 20), 0);
+        r.reduce(juce::jmin(5, area.getWidth() / 20), 0);
 
         auto font = getPopupMenuFont();
 
-        auto maxFontHeight = (float) r.getHeight() / 1.3f;
+        auto maxFontHeight = (float)r.getHeight() / 1.3f;
 
         if (font.getHeight() > maxFontHeight)
-            font.setHeight (maxFontHeight);
+            font.setHeight(maxFontHeight);
 
-        g.setFont (font);
+        g.setFont(font);
 
-        auto tickedArea = r.removeFromLeft (juce::roundToInt (maxFontHeight)).toFloat();
+        auto tickedArea = r.removeFromLeft(juce::roundToInt(maxFontHeight)).toFloat();
         if (isTicked)
         {
-            auto tick = getTickShape (1.0f);
-            g.fillPath (tick, tick.getTransformToScaleToFit (tickedArea.reduced (tickedArea.getWidth() / 5, 0).toFloat(), true));
+            auto tick = getTickShape(1.0f);
+            g.fillPath(tick, tick.getTransformToScaleToFit(
+                                 tickedArea.reduced(tickedArea.getWidth() / 5, 0).toFloat(), true));
         }
 
         if (hasSubMenu)
         {
             auto arrowH = 0.6f * getPopupMenuFont().getAscent();
 
-            auto x = static_cast<float> (r.removeFromRight ((int) arrowH).getX());
-            auto halfH = static_cast<float> (r.getCentreY());
+            auto x = static_cast<float>(r.removeFromRight((int)arrowH).getX());
+            auto halfH = static_cast<float>(r.getCentreY());
 
             juce::Path path;
-            path.startNewSubPath (x, halfH - arrowH * 0.5f);
-            path.lineTo (x + arrowH * 0.6f, halfH);
-            path.lineTo (x, halfH + arrowH * 0.5f);
+            path.startNewSubPath(x, halfH - arrowH * 0.5f);
+            path.lineTo(x + arrowH * 0.6f, halfH);
+            path.lineTo(x, halfH + arrowH * 0.5f);
 
-            g.strokePath (path, juce::PathStrokeType (2.0f));
+            g.strokePath(path, juce::PathStrokeType(2.0f));
         }
 
-        r.removeFromRight (3);
-        g.drawFittedText (text, r, juce::Justification::centredLeft, 1);
+        r.removeFromRight(3);
+        g.drawFittedText(text, r, juce::Justification::centredLeft, 1);
 
         // Custom behaviour. Draw icon to the right of the text. Used for mono/stereo icons!
         if (icon != nullptr)
         {
-        #if JUCE_VERSION >= 0x080000
+#if JUCE_VERSION >= 0x080000
             const auto stringWidth = juce::GlyphArrangement::getStringWidthInt(font, text);
-        #else
+#else
             const auto stringWidth = font.getStringWidth(text);
-        #endif
-            r.removeFromLeft (stringWidth+5).toFloat();
+#endif
+            r.removeFromLeft(stringWidth + 5).toFloat();
             auto iconArea{r};
             // Reduce the icon size compared to the text, so it doesn't draw to much attention
             const auto reduceHeightBy{iconArea.getHeight() * 0.6};
-            iconArea.setHeight(iconArea.getHeight()-reduceHeightBy);
-            iconArea.setY(iconArea.getY() + (reduceHeightBy/2)); // Make sure the icon is still centered
-            icon->drawWithin (g, iconArea.toFloat(), juce::RectanglePlacement::xLeft | juce::RectanglePlacement::yMid | juce::RectanglePlacement::onlyReduceInSize, isActive ? 0.8f : 0.5f);
-            r.removeFromLeft (juce::roundToInt (maxFontHeight * 0.5f));
+            iconArea.setHeight(iconArea.getHeight() - reduceHeightBy);
+            iconArea.setY(iconArea.getY() +
+                          (reduceHeightBy / 2)); // Make sure the icon is still centered
+            icon->drawWithin(g, iconArea.toFloat(),
+                             juce::RectanglePlacement::xLeft | juce::RectanglePlacement::yMid |
+                                 juce::RectanglePlacement::onlyReduceInSize,
+                             isActive ? 0.8f : 0.5f);
+            r.removeFromLeft(juce::roundToInt(maxFontHeight * 0.5f));
         }
 
         if (shortcutKeyText.isNotEmpty())
         {
             auto f2 = font;
-            f2.setHeight (f2.getHeight() * 0.75f);
-            f2.setHorizontalScale (0.95f);
-            g.setFont (f2);
+            f2.setHeight(f2.getHeight() * 0.75f);
+            f2.setHorizontalScale(0.95f);
+            g.setFont(f2);
 
-            g.drawText (shortcutKeyText, r, juce::Justification::centredRight, true);
+            g.drawText(shortcutKeyText, r, juce::Justification::centredRight, true);
         }
     }
 }
@@ -764,11 +767,14 @@ struct Picker : public juce::Component, public juce::TextEditor::Listener
         if (AirwinRegistry::namesByCollection.find(coll) != AirwinRegistry::namesByCollection.end())
             inCol = AirwinRegistry::namesByCollection.at(coll);
 
-        const auto processorIsMono{ editor->processor.getTotalNumInputChannels()== 1 && editor->processor.getTotalNumOutputChannels() == 1 };
-        const auto stereoPluginsInMono{ editor->processor.properties->getBoolValue("stereoPluginsInMono", true) };
+        const auto processorIsMono{editor->processor.getTotalNumInputChannels() == 1 &&
+                                   editor->processor.getTotalNumOutputChannels() == 1};
+        const auto stereoPluginsInMono{
+            editor->processor.properties->getBoolValue("stereoPluginsInMono", true)};
         for (auto r : AirwinRegistry::fxAlphaOrdering)
         {
-            if (!stereoPluginsInMono && processorIsMono && !AirwinRegistry::registry[r].isMono) {
+            if (!stereoPluginsInMono && processorIsMono && !AirwinRegistry::registry[r].isMono)
+            {
                 continue;
             }
 
@@ -1674,7 +1680,8 @@ AWConsolidatedAudioProcessorEditor::AWConsolidatedAudioProcessorEditor(
 
 AWConsolidatedAudioProcessorEditor::~AWConsolidatedAudioProcessorEditor()
 {
-    // Ensure that no popup menu lingers after editor has been closed... (Seen with AU plugin in both Logic Pro and Reaper)
+    // Ensure that no popup menu lingers after editor has been closed... (Seen with AU plugin in
+    // both Logic Pro and Reaper)
     juce::PopupMenu::dismissAllActiveMenus();
 
     // release any references to the look and feel
@@ -1909,7 +1916,8 @@ void AWConsolidatedAudioProcessorEditor::jog(int dir)
     else
         postRebuildFocus = JOG_UP;
 
-    const auto processorIsMono{ processor.getTotalNumInputChannels()== 1 && processor.getTotalNumOutputChannels() == 1 };
+    const auto processorIsMono{processor.getTotalNumInputChannels() == 1 &&
+                               processor.getTotalNumOutputChannels() == 1};
     const int sidx = processor.curentProcessorIndex;
 
     if (coll == favoritesCollection && !favoritesList.empty())
@@ -1919,7 +1927,7 @@ void AWConsolidatedAudioProcessorEditor::jog(int dir)
         std::vector<std::string> v(favoritesList.begin(), favoritesList.end());
 
         // Remove favorites that is not currently supported
-        auto end = std::remove_if(v.begin(), v.end(),[processorIsMono](const auto& name) {
+        auto end = std::remove_if(v.begin(), v.end(), [processorIsMono](const auto &name) {
             const auto rg = AirwinRegistry::registry[AirwinRegistry::nameToIndex[name]];
             return (processorIsMono && !rg.isMono);
         });
@@ -1947,8 +1955,8 @@ void AWConsolidatedAudioProcessorEditor::jog(int dir)
         }
     }
 
-    if (coll == allCollection || AirwinRegistry::namesByCollection.find(coll) ==
-                                          AirwinRegistry::namesByCollection.end())
+    if (coll == allCollection ||
+        AirwinRegistry::namesByCollection.find(coll) == AirwinRegistry::namesByCollection.end())
     {
         auto nx = neighbor(processor.curentProcessorIndex, dir);
         while (nx != sidx)
@@ -1985,9 +1993,11 @@ void AWConsolidatedAudioProcessorEditor::showEffectsMenu(bool justCurrentCategor
 {
     auto p = juce::PopupMenu();
     const auto &ent = AirwinRegistry::registry[processor.curentProcessorIndex];
-    const auto processorIsMono{ processor.getTotalNumInputChannels()== 1 && processor.getTotalNumOutputChannels() == 1 };
-    const auto stereoPluginsInMono{ processor.properties->getBoolValue("stereoPluginsInMono", true) };
-    const auto alwaysShowMonoStereoIcon{ processor.properties->getBoolValue("alwaysShowMonoStereoIcon", false) };
+    const auto processorIsMono{processor.getTotalNumInputChannels() == 1 &&
+                               processor.getTotalNumOutputChannels() == 1};
+    const auto stereoPluginsInMono{processor.properties->getBoolValue("stereoPluginsInMono", true)};
+    const auto alwaysShowMonoStereoIcon{
+        processor.properties->getBoolValue("alwaysShowMonoStereoIcon", false)};
 
     p.setLookAndFeel(popupLnf.get());
     if (justCurrentCategory)
@@ -2014,7 +2024,7 @@ void AWConsolidatedAudioProcessorEditor::showEffectsMenu(bool justCurrentCategor
                 i.isEnabled = stereoPluginsInMono || !processorIsMono || ig.isMono;
                 i.isTicked = f == ent.name;
                 if (processorIsMono || alwaysShowMonoStereoIcon)
-                    i.image = std::move ((ig.isMono ? monoIcon : stereoIcon)->createCopy());
+                    i.image = std::move((ig.isMono ? monoIcon : stereoIcon)->createCopy());
                 i.action = [f, w = juce::Component::SafePointer(this)]() {
                     if (w)
                     {
@@ -2022,11 +2032,12 @@ void AWConsolidatedAudioProcessorEditor::showEffectsMenu(bool justCurrentCategor
                         w->processor.pushResetTypeFromUI(AirwinRegistry::nameToIndex.at(f));
                     }
                 };
-                sm.addItem (std::move(i));
+                sm.addItem(std::move(i));
             }
         }
 
-        if (sm.getNumItems() > 1) {
+        if (sm.getNumItems() > 1)
+        {
             p.addSubMenu("Favorites", sm);
             p.addSeparator();
         }
@@ -2102,12 +2113,13 @@ void AWConsolidatedAudioProcessorEditor::showEffectsMenu(bool justCurrentCategor
                 }
             }
 
-            if (include) {
+            if (include)
+            {
                 juce::PopupMenu::Item i(nm);
                 i.isEnabled = stereoPluginsInMono || !processorIsMono || rg.isMono;
                 i.isTicked = nm == ent.name;
                 if (processorIsMono || alwaysShowMonoStereoIcon)
-                    i.image = std::move ((rg.isMono ? monoIcon : stereoIcon)->createCopy());
+                    i.image = std::move((rg.isMono ? monoIcon : stereoIcon)->createCopy());
                 i.action = [nm, w = juce::Component::SafePointer(this)]() {
                     if (w)
                     {
@@ -2115,7 +2127,7 @@ void AWConsolidatedAudioProcessorEditor::showEffectsMenu(bool justCurrentCategor
                         w->processor.pushResetTypeFromUI(AirwinRegistry::nameToIndex.at(nm));
                     }
                 };
-                target->addItem (std::move(i));
+                target->addItem(std::move(i));
             }
         }
         if (!justCurrentCategory && sub.getNumItems() > 0)
@@ -2248,38 +2260,47 @@ juce::PopupMenu AWConsolidatedAudioProcessorEditor::makeSettingsMenu(bool withHe
     settingsMenu.addSeparator();
     juce::PopupMenu layout;
     juce::String busLayout{"Unknown -> "};
-    if ( processor.getTotalNumInputChannels() == 1 )
+    if (processor.getTotalNumInputChannels() == 1)
         busLayout = "Mono -> ";
-    else if (processor.getTotalNumInputChannels() == 2 )
+    else if (processor.getTotalNumInputChannels() == 2)
         busLayout = "Stereo -> ";
-    if ( processor.getTotalNumOutputChannels() == 1 )
+    if (processor.getTotalNumOutputChannels() == 1)
         busLayout += "Mono";
-    else if (processor.getTotalNumOutputChannels() == 2 )
+    else if (processor.getTotalNumOutputChannels() == 2)
         busLayout += "Stereo";
     else
         busLayout += "Unknown";
 
     layout.addSectionHeader("Mono behaviour");
     layout.addSeparator();
-    layout.addItem("Allow stereo plugins in mono mode (global)", true, processor.properties->getBoolValue("stereoPluginsInMono", true),
-        [w = juce::Component::SafePointer(this)]() {
-            if (!w)
-                return;
-            w->processor.properties->setValue("stereoPluginsInMono", !w->processor.properties->getBoolValue("stereoPluginsInMono", true));
-        });
+    layout.addItem("Allow stereo plugins in mono mode (global)", true,
+                   processor.properties->getBoolValue("stereoPluginsInMono", true),
+                   [w = juce::Component::SafePointer(this)]() {
+                       if (!w)
+                           return;
+                       w->processor.properties->setValue(
+                           "stereoPluginsInMono",
+                           !w->processor.properties->getBoolValue("stereoPluginsInMono", true));
+                   });
     layout.addSeparator();
-    layout.addItem("Output only L channel", true, *processor.monoBehaviourParameter == AWConsolidatedAudioProcessor::MonoBehaviourParameter::LeftOnly,
-        [w = juce::Component::SafePointer(this)]() {
-            if (!w)
-                return;
-            *w->processor.monoBehaviourParameter = AWConsolidatedAudioProcessor::MonoBehaviourParameter::LeftOnly;
-        });
-    layout.addItem("Output L+R channel", true, *processor.monoBehaviourParameter == AWConsolidatedAudioProcessor::MonoBehaviourParameter::LeftRightSum,
-        [w = juce::Component::SafePointer(this)]() {
-            if (!w)
-                return;
-            *w->processor.monoBehaviourParameter = AWConsolidatedAudioProcessor::MonoBehaviourParameter::LeftRightSum;
-        });
+    layout.addItem("Output only L channel", true,
+                   *processor.monoBehaviourParameter ==
+                       AWConsolidatedAudioProcessor::MonoBehaviourParameter::LeftOnly,
+                   [w = juce::Component::SafePointer(this)]() {
+                       if (!w)
+                           return;
+                       *w->processor.monoBehaviourParameter =
+                           AWConsolidatedAudioProcessor::MonoBehaviourParameter::LeftOnly;
+                   });
+    layout.addItem("Output L+R channel", true,
+                   *processor.monoBehaviourParameter ==
+                       AWConsolidatedAudioProcessor::MonoBehaviourParameter::LeftRightSum,
+                   [w = juce::Component::SafePointer(this)]() {
+                       if (!w)
+                           return;
+                       *w->processor.monoBehaviourParameter =
+                           AWConsolidatedAudioProcessor::MonoBehaviourParameter::LeftRightSum;
+                   });
     layout.addSeparator();
     layout.addItem("Bus layout: " + busLayout, false, false, []() {});
     settingsMenu.addSubMenu("Channel Layout", layout);

--- a/src-juce/AWConsolidatedEditor.h
+++ b/src-juce/AWConsolidatedEditor.h
@@ -120,10 +120,10 @@ struct AWLookAndFeel : public juce::LookAndFeel_V4
 struct AWEffectPopupLookAndFeel : public juce::LookAndFeel_V4
 {
     AWEffectPopupLookAndFeel() = default;
-    void drawPopupMenuItem (juce::Graphics&, const juce::Rectangle<int>& area,
-                            bool isSeparator, bool isActive, bool isHighlighted, bool isTicked, bool hasSubMenu,
-                            const juce::String& text, const juce::String& shortcutKeyText,
-                            const juce::Drawable* icon, const juce::Colour* textColour) override;
+    void drawPopupMenuItem(juce::Graphics &, const juce::Rectangle<int> &area, bool isSeparator,
+                           bool isActive, bool isHighlighted, bool isTicked, bool hasSubMenu,
+                           const juce::String &text, const juce::String &shortcutKeyText,
+                           const juce::Drawable *icon, const juce::Colour *textColour) override;
 };
 
 class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor,
@@ -205,7 +205,7 @@ class AWConsolidatedAudioProcessorEditor : public juce::AudioProcessorEditor,
     void unstreamFavorites();
     juce::File getSettingsDirectory(bool makeDir) const;
     juce::File getFavoritesFile(bool makeDir) const;
-    bool loadCustomDocumentation(const juce::String& fileName, juce::String& outContent) const;
+    bool loadCustomDocumentation(const juce::String &fileName, juce::String &outContent) const;
     std::set<std::string> favoritesList{};
 
   private:

--- a/src-juce/AWConsolidatedProcessor.h
+++ b/src-juce/AWConsolidatedProcessor.h
@@ -161,7 +161,7 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
     void setupParamDisplaysFromDisplayProcessor(int index);
 
     std::atomic<bool> refreshUI{false},
-    rebuildUI{false}; // repaint vs re-setup everything. Value vs type
+        rebuildUI{false}; // repaint vs re-setup everything. Value vs type
 
     struct APFPublicDefault : public juce::AudioParameterFloat
     {
@@ -208,7 +208,7 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
     struct CubicDBParam : public APFPublicDefault
     {
         static constexpr float maxDb{18.0};
-        static constexpr double maxLev{7.943282347242815}; // pow(10, maxDb/20)
+        static constexpr double maxLev{7.943282347242815};      // pow(10, maxDb/20)
         static constexpr double defaultVal{0.5011872336272724}; // 1.0 / cbrt(maxLeb)
         CubicDBParam(const juce::ParameterID &id, const juce::String &parameterName)
             : APFPublicDefault(id, parameterName, juce::NormalisableRange<float>(0.0, 1.0),
@@ -254,39 +254,44 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
 
         float getDefaultValue() const override { return defaultVal; }
 
-        template<typename T>
-        T getAmplitude() const {
+        template <typename T> T getAmplitude() const
+        {
             T lev = (T)get();
             lev = lev * lev * lev * maxLev;
             return lev;
         }
 
-        bool isAmplifiyingOrAttenuating() const
-        {
-            return std::fabs(get() - defaultVal) > 5e-6;
-        }
+        bool isAmplifiyingOrAttenuating() const { return std::fabs(get() - defaultVal) > 5e-6; }
     };
 
     struct MonoBehaviourParameter : public juce::AudioParameterInt
     {
-        enum MonoBehaviour {
+        enum MonoBehaviour
+        {
             LeftOnly,
             RightOnly,
             LeftRightSum,
             NumOfElements
         };
 
-        MonoBehaviourParameter(const juce::ParameterID& idToUse,
-                               const juce::String& nameToUse,
+        MonoBehaviourParameter(const juce::ParameterID &idToUse, const juce::String &nameToUse,
                                MonoBehaviour def,
-                              const juce::AudioParameterIntAttributes& attributes)
-            : juce::AudioParameterInt(idToUse, nameToUse, 0, MonoBehaviour::NumOfElements-1, static_cast<int>(def), attributes)
+                               const juce::AudioParameterIntAttributes &attributes)
+            : juce::AudioParameterInt(idToUse, nameToUse, 0, MonoBehaviour::NumOfElements - 1,
+                                      static_cast<int>(def), attributes)
         {
         }
 
-        MonoBehaviour get() const noexcept { return static_cast<MonoBehaviour>(juce::AudioParameterInt::get()); }
+        MonoBehaviour get() const noexcept
+        {
+            return static_cast<MonoBehaviour>(juce::AudioParameterInt::get());
+        }
         operator MonoBehaviour() const noexcept { return get(); }
-        MonoBehaviourParameter& operator= (MonoBehaviour newValue) { juce::AudioParameterInt::operator=(static_cast<int>(newValue)); return *this; };
+        MonoBehaviourParameter &operator=(MonoBehaviour newValue)
+        {
+            juce::AudioParameterInt::operator=(static_cast<int>(newValue));
+            return *this;
+        };
     };
 
     //==============================================================================
@@ -311,9 +316,8 @@ class AWConsolidatedAudioProcessor : public juce::AudioProcessor,
 
     std::unique_ptr<juce::PropertiesFile> properties;
 
-private:
-    template<typename T>
-    struct PrecisionDependantProcessing
+  private:
+    template <typename T> struct PrecisionDependantProcessing
     {
         std::unique_ptr<juce::AudioBuffer<T>> monoBuffer;
 
@@ -324,16 +328,23 @@ private:
     PrecisionDependantProcessing<float> precisionProcessingFloat;
     PrecisionDependantProcessing<double> precisionProcessingDouble;
 
-    template<class T>
-    PrecisionDependantProcessing<T>& getPrecisionDependantProcessing();
+    template <class T> PrecisionDependantProcessing<T> &getPrecisionDependantProcessing();
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AWConsolidatedAudioProcessor)
 };
 
-template <> inline
-AWConsolidatedAudioProcessor::PrecisionDependantProcessing<float>& AWConsolidatedAudioProcessor::getPrecisionDependantProcessing() { return precisionProcessingFloat; }
+template <>
+inline AWConsolidatedAudioProcessor::PrecisionDependantProcessing<float> &
+AWConsolidatedAudioProcessor::getPrecisionDependantProcessing()
+{
+    return precisionProcessingFloat;
+}
 
-template <> inline
-AWConsolidatedAudioProcessor::PrecisionDependantProcessing<double>& AWConsolidatedAudioProcessor::getPrecisionDependantProcessing() { return precisionProcessingDouble; }
+template <>
+inline AWConsolidatedAudioProcessor::PrecisionDependantProcessing<double> &
+AWConsolidatedAudioProcessor::getPrecisionDependantProcessing()
+{
+    return precisionProcessingDouble;
+}
 
 #endif // SURGE_SRC_SURGE_FX_SURGEFXPROCESSOR_H

--- a/src-rack/Airwin2Rack.cpp
+++ b/src-rack/Airwin2Rack.cpp
@@ -1,13 +1,15 @@
 /*
-* Airwin2Rack - an adaptation of the airwindows effect suite for VCVRack
-*
-* This source released under the MIT License, found in ~/LICENSE.md.
-*
-* Copyright 2023 by the authors as described in the github transaction log
-*/
+ * Airwin2Rack - an adaptation of the airwindows effect suite for VCVRack
+ *
+ * This source released under the MIT License, found in ~/LICENSE.md.
+ *
+ * Copyright 2023 by the authors as described in the github transaction log
+ */
 
 #include "Airwin2Rack.hpp"
+#include "AirwinRegistry.h"
 
+#include <functional>
 #include <unordered_set>
 
 static std::unique_ptr<std::unordered_set<rack::Model *>> models;
@@ -16,6 +18,9 @@ rack::Plugin *pluginInstance;
 
 __attribute__((__visibility__("default"))) void init(rack::Plugin *p)
 {
+    AirwinRegistry::filterAndRebuildRegistry(
+        [](auto &r) { return (size_t)r.nParams >= nAWRackParams; });
+
     pluginInstance = p;
 
     p->addModel(airwin2RackModel);

--- a/src-rack/Airwin2Rack.hpp
+++ b/src-rack/Airwin2Rack.hpp
@@ -1,10 +1,10 @@
 /*
-* Airwin2Rack - an adaptation of the airwindows effect suite for VCVRack
-*
-* This source released under the MIT License, found in ~/LICENSE.md.
-*
-* Copyright 2023 by the authors as described in the github transaction log
-*/
+ * Airwin2Rack - an adaptation of the airwindows effect suite for VCVRack
+ *
+ * This source released under the MIT License, found in ~/LICENSE.md.
+ *
+ * Copyright 2023 by the authors as described in the github transaction log
+ */
 
 #ifndef INCLUDE_AIRWIN2RACK_HPP
 #define INCLUDE_AIRWIN2RACK_HPP
@@ -13,6 +13,8 @@
 
 #define SCREW_WIDTH 15
 #define RACK_HEIGHT 380
+
+static constexpr size_t nAWRackParams{10};
 
 extern rack::Plugin *pluginInstance;
 extern rack::Model *airwin2RackModel;

--- a/src/AirwinRegistry.h
+++ b/src/AirwinRegistry.h
@@ -51,28 +51,28 @@ struct AirwinRegistry
 
     static int registerAirwindow(const awReg &r)
     {
-        if (r.nParams > 10)
+        if (r.whatText.empty())
         {
-            if (r.name == "CStrip" || r.name == "Pafnuty")
-            {
-                // I know about these
-            }
-            else
-            {
-                // std::cout << "PROBLEM : " << r.name << " " << r.nParams << std::endl;
-            }
+            std::cout << r.name << " / " << r.category << " missing what text" << std::endl;
         }
-        else if (r.whatText.empty())
-        {
-            // std::cout << r.name << " / " << r.category << " missing what text" << std::endl;
-        }
-        else
-        {
-            registry.emplace_back(r);
-        }
+        registry.emplace_back(r);
 
         return registry.size();
     }
+
+    static void filterAndRebuildRegistry(std::function<bool(const awReg &)> removePredicate)
+    {
+        nameToIndex.clear();
+        categories.clear();
+        fxByCategory.clear();
+        fxByCategoryChrisOrder.clear();
+        fxAlphaOrdering.clear();
+        fxChrisOrdering.clear();
+        registry.erase(std::remove_if(registry.begin(), registry.end(), removePredicate),
+                       registry.end());
+        completeRegistry();
+    }
+
     static int completeRegistry()
     {
         int idx{0};

--- a/src/airwin_consolidated_base.h
+++ b/src/airwin_consolidated_base.h
@@ -48,7 +48,8 @@ struct AirwinConsolidatedBase
     virtual void programsAreChunks(bool) {}
 
     virtual void processReplacing(float **inputs, float **outputs, VstInt32 sampleFrames) = 0;
-    virtual void processDoubleReplacing(double **inputs, double **outputs, VstInt32 sampleFrames) = 0;
+    virtual void processDoubleReplacing(double **inputs, double **outputs,
+                                        VstInt32 sampleFrames) = 0;
 
     virtual float
     getParameter(VstInt32 index) = 0; // get the parameter value at the specified index


### PR DESCRIPTION
The 10 param constraint moves to be something a client can enforce rather than enforced at registry creation time. We still enforce it in the rack and juce plugins but don't have to in the future.

Also adjust the rack and juce plugins so that if you don't enforce it they truncate rather than crash long param lists