### PR TITLE
Make it possible to build an lv2 bundle with separate effects

### DIFF
--- a/.github/workflows/build-lv2-individual.yml
+++ b/.github/workflows/build-lv2-individual.yml
@@ -1,0 +1,50 @@
+name: Build LV2 Individual
+on:
+  push:
+    branches:
+      - test-lv2-individual-ci
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build_lv2_individual_linux:
+    name: LV2 Individual Build - ubuntu20-x64
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
+      options: --user root
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install LV2 build dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y build-essential cmake ninja-build pkg-config lv2-dev
+
+      - name: Configure LV2 individual build
+        run: |
+          cmake -S . -B ./build-lv2-ind-ci -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_LV2_INDIVIDUAL=ON
+
+      - name: Build LV2 individual bundle
+        run: |
+          cmake --build ./build-lv2-ind-ci --target airwindows-individual-lv2 --parallel 3
+
+      - name: Show LV2 bundle contents
+        run: |
+          find ./build-lv2-ind-ci/airwindows-individual.lv2 -maxdepth 1 -type f -print
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: build-lv2-ind-ci/airwindows-individual.lv2
+          name: lv2-individual-linux

--- a/.github/workflows/build-lv2-individual.yml
+++ b/.github/workflows/build-lv2-individual.yml
@@ -51,13 +51,31 @@ jobs:
         run: |
           curl -sSL -o /tmp/lv2-smoketest.tar.gz \
             "https://github.com/Joeboy/lv2-smoketest/releases/download/${LV2_SMOKETEST_VERSION}/lv2-smoketest-linux-x86_64.tar.gz"
-          tar -xzf /tmp/lv2-smoketest.tar.gz -C /tmp
-          install -m 0755 /tmp/lv2-smoketest /usr/local/bin/lv2-smoketest
-          lv2-smoketest --help >/dev/null
+          rm -rf /tmp/lv2-smoketest-extract
+          mkdir -p /tmp/lv2-smoketest-extract
+          tar -xzf /tmp/lv2-smoketest.tar.gz -C /tmp/lv2-smoketest-extract
+          smoketest_root="$(find /tmp/lv2-smoketest-extract -mindepth 1 -maxdepth 1 -type d -name lv2-smoketest -print -quit)"
+          if [[ -z "$smoketest_root" ]]; then
+            echo "ERROR: lv2-smoketest directory not found in release archive"
+            find /tmp/lv2-smoketest-extract -maxdepth 3 -print
+            exit 1
+          fi
+
+          smoketest_bin="$smoketest_root/lv2-smoketest"
+          if [[ ! -x "$smoketest_bin" ]]; then
+            echo "ERROR: lv2-smoketest binary not found in release archive"
+            exit 1
+          fi
+
+          echo "LV2_SMOKETEST_BIN=$smoketest_bin" >> "$GITHUB_ENV"
+          echo "LV2_SMOKETEST_LIB=$smoketest_root/lib" >> "$GITHUB_ENV"
+
+          LD_LIBRARY_PATH="$smoketest_root/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+            "$smoketest_bin" --help >/dev/null
 
       - name: Smoke test LV2 plugins
         env:
-          LV2_PATH: ${{ github.workspace }}/build-lv2-ind-ci
+          LV2_PATH: ${{ github.workspace }}/build-lv2-ind-ci:/usr/lib/lv2:/usr/local/lib/lv2
         run: |
           bundle_path="$(realpath ./build-lv2-ind-ci/airwindows-individual.lv2)/"
           if [[ ! -d "$bundle_path" ]]; then
@@ -65,7 +83,9 @@ jobs:
             exit 1
           fi
 
-          lv2-smoketest list-installed-plugins > /tmp/lv2-plugins.json
+          export LD_LIBRARY_PATH="$LV2_SMOKETEST_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+          "$LV2_SMOKETEST_BIN" list-installed-plugins > /tmp/lv2-plugins.json
           echo "Discovered $(jq 'length' /tmp/lv2-plugins.json) total LV2 plugins"
 
           mapfile -t plugin_uris < <(
@@ -77,7 +97,7 @@ jobs:
           echo "Smoke testing ${#plugin_uris[@]} plugin URIs"
           for plugin_uri in "${plugin_uris[@]}"; do
             echo "Smoke testing: $plugin_uri"
-            lv2-smoketest test-plugin-run "$plugin_uri"
+            "$LV2_SMOKETEST_BIN" test-plugin-run "$plugin_uri"
           done
 
       - name: Show LV2 bundle contents

--- a/.github/workflows/build-lv2-individual.yml
+++ b/.github/workflows/build-lv2-individual.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -y build-essential cmake ninja-build pkg-config lv2-dev
+          apt-get install -y build-essential cmake ninja-build pkg-config lv2-dev curl ca-certificates jq
 
       - name: Configure LV2 individual build
         run: |
@@ -44,6 +44,41 @@ jobs:
       - name: Build LV2 individual bundle
         run: |
           cmake --build ./build-lv2-ind-ci --target airwindows-individual-lv2 --parallel 3
+
+      - name: Install lv2-smoketest
+        env:
+          LV2_SMOKETEST_VERSION: v0.1.0-test14
+        run: |
+          curl -sSL -o /tmp/lv2-smoketest.tar.gz \
+            "https://github.com/Joeboy/lv2-smoketest/releases/download/${LV2_SMOKETEST_VERSION}/lv2-smoketest-linux-x86_64.tar.gz"
+          tar -xzf /tmp/lv2-smoketest.tar.gz -C /tmp
+          install -m 0755 /tmp/lv2-smoketest /usr/local/bin/lv2-smoketest
+          lv2-smoketest --help >/dev/null
+
+      - name: Smoke test LV2 plugins
+        env:
+          LV2_PATH: ${{ github.workspace }}/build-lv2-ind-ci
+        run: |
+          bundle_path="$(realpath ./build-lv2-ind-ci/airwindows-individual.lv2)/"
+          if [[ ! -d "$bundle_path" ]]; then
+            echo "ERROR: Missing LV2 bundle directory at $bundle_path"
+            exit 1
+          fi
+
+          lv2-smoketest list-installed-plugins > /tmp/lv2-plugins.json
+          echo "Discovered $(jq 'length' /tmp/lv2-plugins.json) total LV2 plugins"
+
+          mapfile -t plugin_uris < <(
+            jq -r --arg bundle_path "$bundle_path" \
+              '.[] | select(.bundle_path == $bundle_path) | .uri' \
+              /tmp/lv2-plugins.json
+          )
+
+          echo "Smoke testing ${#plugin_uris[@]} plugin URIs"
+          for plugin_uri in "${plugin_uris[@]}"; do
+            echo "Smoke testing: $plugin_uri"
+            lv2-smoketest test-plugin-run "$plugin_uri"
+          done
 
       - name: Show LV2 bundle contents
         run: |

--- a/.github/workflows/build-lv2-individual.yml
+++ b/.github/workflows/build-lv2-individual.yml
@@ -74,8 +74,6 @@ jobs:
             "$smoketest_bin" --help >/dev/null
 
       - name: Smoke test LV2 plugins
-        env:
-          LV2_PATH: ${{ github.workspace }}/build-lv2-ind-ci:/usr/lib/lv2:/usr/local/lib/lv2
         run: |
           bundle_path="$(realpath ./build-lv2-ind-ci/airwindows-individual.lv2)/"
           if [[ ! -d "$bundle_path" ]]; then
@@ -83,13 +81,18 @@ jobs:
             exit 1
           fi
 
+          smoketest_lv2_root="$(mktemp -d)"
+          cp -a "$bundle_path" "$smoketest_lv2_root/"
+          test_bundle_path="$(realpath "$smoketest_lv2_root/airwindows-individual.lv2")/"
+
           export LD_LIBRARY_PATH="$LV2_SMOKETEST_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export LV2_PATH="$smoketest_lv2_root:/usr/lib/lv2:/usr/local/lib/lv2"
 
           "$LV2_SMOKETEST_BIN" list-installed-plugins > /tmp/lv2-plugins.json
           echo "Discovered $(jq 'length' /tmp/lv2-plugins.json) total LV2 plugins"
 
           mapfile -t plugin_uris < <(
-            jq -r --arg bundle_path "$bundle_path" \
+            jq -r --arg bundle_path "$test_bundle_path" \
               '.[] | select(.bundle_path == $bundle_path) | .uri' \
               /tmp/lv2-plugins.json
           )

--- a/.github/workflows/build-lv2-individual.yml
+++ b/.github/workflows/build-lv2-individual.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install lv2-smoketest
         env:
-          LV2_SMOKETEST_VERSION: v0.1.0-test14
+          LV2_SMOKETEST_VERSION: v0.1.0-test19
         run: |
           curl -sSL -o /tmp/lv2-smoketest.tar.gz \
             "https://github.com/Joeboy/lv2-smoketest/releases/download/${LV2_SMOKETEST_VERSION}/lv2-smoketest-linux-x86_64.tar.gz"

--- a/.github/workflows/build-lv2-individual.yml
+++ b/.github/workflows/build-lv2-individual.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  LV2_SMOKETEST_VERSION: v0.1.0
 
 defaults:
   run:
@@ -46,8 +47,6 @@ jobs:
           cmake --build ./build-lv2-ind-ci --target airwindows-individual-lv2 --parallel 3
 
       - name: Install lv2-smoketest
-        env:
-          LV2_SMOKETEST_VERSION: v0.1.0-test19
         run: |
           curl -sSL -o /tmp/lv2-smoketest.tar.gz \
             "https://github.com/Joeboy/lv2-smoketest/releases/download/${LV2_SMOKETEST_VERSION}/lv2-smoketest-linux-x86_64.tar.gz"
@@ -75,14 +74,14 @@ jobs:
 
       - name: Smoke test LV2 plugins
         run: |
-          bundle_path="$(realpath ./build-lv2-ind-ci/airwindows-individual.lv2)/"
+          bundle_path="$(realpath ./build-lv2-ind-ci/airwindows-individual.lv2)"
           if [[ ! -d "$bundle_path" ]]; then
             echo "ERROR: Missing LV2 bundle directory at $bundle_path"
             exit 1
           fi
 
           smoketest_lv2_root="$(mktemp -d)"
-          cp -a "$bundle_path" "$smoketest_lv2_root/"
+          cp -a "$bundle_path" "$smoketest_lv2_root/airwindows-individual.lv2"
           test_bundle_path="$(realpath "$smoketest_lv2_root/airwindows-individual.lv2")/"
 
           export LD_LIBRARY_PATH="$LV2_SMOKETEST_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
@@ -91,7 +90,10 @@ jobs:
           "$LV2_SMOKETEST_BIN" list-installed-plugins > /tmp/lv2-plugins.json
           echo "Discovered $(jq 'length' /tmp/lv2-plugins.json) total LV2 plugins"
 
-          mapfile -t plugin_uris < <(
+          plugin_uris=()
+          while IFS= read -r plugin_uri; do
+            plugin_uris+=("$plugin_uri")
+          done < <(
             jq -r --arg bundle_path "$test_bundle_path" \
               '.[] | select(.bundle_path == $bundle_path) | .uri' \
               /tmp/lv2-plugins.json
@@ -117,3 +119,226 @@ jobs:
         with:
           path: artifact
           name: lv2-individual-linux
+
+  build_lv2_individual_windows:
+    name: LV2 Individual Build - windows-x64
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-lv2
+            mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-jq
+            unzip
+
+      - name: Configure LV2 individual build
+        run: |
+          cmake -S . -B ./build-lv2-ind-ci -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_LV2_INDIVIDUAL=ON
+
+      - name: Build LV2 individual bundle
+        run: |
+          cmake --build ./build-lv2-ind-ci --target airwindows-individual-lv2 --parallel 3
+
+      - name: Install lv2-smoketest
+        run: |
+          smoketest_url="https://github.com/Joeboy/lv2-smoketest/releases/download/${LV2_SMOKETEST_VERSION}/lv2-smoketest-windows-x86_64.zip"
+          curl -sSL -o /tmp/lv2-smoketest.zip "$smoketest_url"
+          rm -rf /tmp/lv2-smoketest-extract
+          mkdir -p /tmp/lv2-smoketest-extract
+          unzip_status=0
+          unzip -q /tmp/lv2-smoketest.zip -d /tmp/lv2-smoketest-extract || unzip_status=$?
+          if [[ "$unzip_status" -gt 1 ]]; then
+            echo "ERROR: unzip failed with status $unzip_status"
+            exit "$unzip_status"
+          fi
+          smoketest_root="$(find /tmp/lv2-smoketest-extract -mindepth 1 -maxdepth 1 -type d -name lv2-smoketest -print -quit)"
+          if [[ -z "$smoketest_root" ]]; then
+            echo "ERROR: lv2-smoketest directory not found in release archive"
+            find /tmp/lv2-smoketest-extract -maxdepth 3 -print
+            exit 1
+          fi
+
+          smoketest_bin="$smoketest_root/lv2-smoketest.exe"
+          if [[ ! -f "$smoketest_bin" ]]; then
+            echo "ERROR: lv2-smoketest binary not found in release archive"
+            exit 1
+          fi
+
+          echo "LV2_SMOKETEST_BIN=$smoketest_bin" >> "$GITHUB_ENV"
+          echo "LV2_SMOKETEST_LIB=$smoketest_root/lib" >> "$GITHUB_ENV"
+
+          PATH="$smoketest_root/lib:$PATH" "$smoketest_bin" --help >/dev/null
+
+      - name: Smoke test LV2 plugins
+        run: |
+          bundle_path="$(realpath ./build-lv2-ind-ci/airwindows-individual.lv2)"
+          if [[ ! -d "$bundle_path" ]]; then
+            echo "ERROR: Missing LV2 bundle directory at $bundle_path"
+            exit 1
+          fi
+
+          smoketest_lv2_root="$(mktemp -d)"
+          cp -a "$bundle_path" "$smoketest_lv2_root/airwindows-individual.lv2"
+          test_bundle_path="$(realpath "$smoketest_lv2_root/airwindows-individual.lv2")/"
+          smoketest_lv2_root_win="$(cygpath -wm "$smoketest_lv2_root")"
+
+          export PATH="$LV2_SMOKETEST_LIB:$PATH"
+          export LV2_PATH="$smoketest_lv2_root_win"
+
+          "$LV2_SMOKETEST_BIN" list-installed-plugins > /tmp/lv2-plugins.json
+          echo "Discovered $(jq 'length' /tmp/lv2-plugins.json) total LV2 plugins"
+
+          plugin_uris=()
+          while IFS= read -r plugin_uri; do
+            plugin_uri="${plugin_uri%$'\r'}"
+            plugin_uri="${plugin_uri%$'\n'}"
+            [[ -z "$plugin_uri" ]] && continue
+            plugin_uris+=("$plugin_uri")
+          done < <(
+            jq -r --arg bundle_path "$test_bundle_path" '.[] | select(.bundle_path == $bundle_path) | .uri' /tmp/lv2-plugins.json
+          )
+
+          echo "Smoke testing ${#plugin_uris[@]} plugin URIs"
+          for plugin_uri in "${plugin_uris[@]}"; do
+            echo "Smoke testing: '$plugin_uri'"
+            "$LV2_SMOKETEST_BIN" test-plugin-run "$plugin_uri"
+          done
+
+      - name: Show LV2 bundle contents
+        run: |
+          find ./build-lv2-ind-ci/airwindows-individual.lv2 -maxdepth 1 -type f -print
+
+      - name: Stage LV2 artifact
+        run: |
+          mkdir -p ./artifact
+          cp -a ./build-lv2-ind-ci/airwindows-individual.lv2 ./artifact/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: artifact
+          name: lv2-individual-windows
+
+  build_lv2_individual_macos:
+    name: LV2 Individual Build - macos-arm64
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install LV2 build dependencies
+        run: |
+          brew install cmake ninja lv2 lilv pkg-config jq
+
+      - name: Configure LV2 individual build
+        run: |
+          cmake -S . -B ./build-lv2-ind-ci -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_LV2_INDIVIDUAL=ON
+
+      - name: Build LV2 individual bundle
+        run: |
+          cmake --build ./build-lv2-ind-ci --target airwindows-individual-lv2 --parallel 3
+
+      - name: Install lv2-smoketest
+        run: |
+          curl -sSL -o /tmp/lv2-smoketest.tar.gz \
+            "https://github.com/Joeboy/lv2-smoketest/releases/download/${LV2_SMOKETEST_VERSION}/lv2-smoketest-macos-aarch64.tar.gz"
+          rm -rf /tmp/lv2-smoketest-extract
+          mkdir -p /tmp/lv2-smoketest-extract
+          tar -xzf /tmp/lv2-smoketest.tar.gz -C /tmp/lv2-smoketest-extract
+          smoketest_root="$(find /tmp/lv2-smoketest-extract -mindepth 1 -maxdepth 1 -type d -name lv2-smoketest -print -quit)"
+          if [[ -z "$smoketest_root" ]]; then
+            echo "ERROR: lv2-smoketest directory not found in release archive"
+            find /tmp/lv2-smoketest-extract -maxdepth 3 -print
+            exit 1
+          fi
+
+          smoketest_bin="$smoketest_root/lv2-smoketest"
+          if [[ ! -x "$smoketest_bin" ]]; then
+            echo "ERROR: lv2-smoketest binary not found in release archive"
+            exit 1
+          fi
+
+          dyld_paths="$smoketest_root/lib"
+          for pkg in lilv-0 sord-0 sratom-0 serd-0; do
+            if pkg-config --exists "$pkg"; then
+              libdir="$(pkg-config --variable=libdir "$pkg")"
+              dyld_paths="$dyld_paths:$libdir"
+            fi
+          done
+
+          echo "LV2_SMOKETEST_BIN=$smoketest_bin" >> "$GITHUB_ENV"
+          echo "LV2_SMOKETEST_DYLD_PATH=$dyld_paths" >> "$GITHUB_ENV"
+
+          DYLD_LIBRARY_PATH="$dyld_paths${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" \
+            "$smoketest_bin" --help >/dev/null
+
+      - name: Smoke test LV2 plugins
+        run: |
+          bundle_path="$(realpath ./build-lv2-ind-ci/airwindows-individual.lv2)"
+          if [[ ! -d "$bundle_path" ]]; then
+            echo "ERROR: Missing LV2 bundle directory at $bundle_path"
+            exit 1
+          fi
+
+          smoketest_lv2_root="$(mktemp -d)"
+          cp -a "$bundle_path" "$smoketest_lv2_root/airwindows-individual.lv2"
+          test_bundle_path="$(realpath "$smoketest_lv2_root/airwindows-individual.lv2")/"
+
+          export DYLD_LIBRARY_PATH="$LV2_SMOKETEST_DYLD_PATH${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+          export LV2_PATH="$smoketest_lv2_root"
+          echo "LV2_PATH=$LV2_PATH"
+          ls -la "$LV2_PATH"
+
+          "$LV2_SMOKETEST_BIN" list-installed-plugins > /tmp/lv2-plugins.json
+          echo "Discovered $(jq 'length' /tmp/lv2-plugins.json) total LV2 plugins"
+
+          plugin_uris=()
+          while IFS= read -r plugin_uri; do
+            plugin_uris+=("$plugin_uri")
+          done < <(
+            jq -r --arg bundle_path "$test_bundle_path" \
+              '.[] | select(.bundle_path == $bundle_path) | .uri' \
+              /tmp/lv2-plugins.json
+          )
+
+          echo "Smoke testing ${#plugin_uris[@]} plugin URIs"
+          for plugin_uri in "${plugin_uris[@]}"; do
+            echo "Smoke testing: $plugin_uri"
+            "$LV2_SMOKETEST_BIN" test-plugin-run "$plugin_uri"
+          done
+
+      - name: Show LV2 bundle contents
+        run: |
+          find ./build-lv2-ind-ci/airwindows-individual.lv2 -maxdepth 1 -type f -print
+
+      - name: Stage LV2 artifact
+        run: |
+          mkdir -p ./artifact
+          cp -a ./build-lv2-ind-ci/airwindows-individual.lv2 ./artifact/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: artifact
+          name: lv2-individual-macos

--- a/.github/workflows/build-lv2-individual.yml
+++ b/.github/workflows/build-lv2-individual.yml
@@ -407,10 +407,11 @@ jobs:
           set -euo pipefail
           tag_name="${GITHUB_REF_NAME}"
 
-          if ! gh release view "$tag_name" >/dev/null 2>&1; then
+          if ! gh release view "$tag_name" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create "$tag_name" \
+              --repo "$GITHUB_REPOSITORY" \
               --title "$tag_name" \
               --notes "Automated LV2 individual bundle release for $tag_name"
           fi
 
-          gh release upload "$tag_name" ./release-dist/* --clobber
+          gh release upload "$tag_name" ./release-dist/* --clobber --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/build-lv2-individual.yml
+++ b/.github/workflows/build-lv2-individual.yml
@@ -28,7 +28,7 @@ jobs:
           apt-get install -y git
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -115,7 +115,7 @@ jobs:
           cp -a ./build-lv2-ind-ci/airwindows-individual.lv2 ./artifact/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           path: artifact
           name: lv2-individual-linux
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -230,7 +230,7 @@ jobs:
           cp -a ./build-lv2-ind-ci/airwindows-individual.lv2 ./artifact/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           path: artifact
           name: lv2-individual-windows
@@ -241,13 +241,24 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Install LV2 build dependencies
         run: |
-          brew install cmake ninja lv2 lilv pkg-config jq
+          deps=(cmake ninja lv2 lilv pkg-config jq)
+          missing=()
+          for dep in "${deps[@]}"; do
+            if ! brew list --formula "$dep" >/dev/null 2>&1; then
+              missing+=("$dep")
+            fi
+          done
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            brew install "${missing[@]}"
+          else
+            echo "All Homebrew dependencies already installed"
+          fi
 
       - name: Configure LV2 individual build
         run: |
@@ -338,7 +349,7 @@ jobs:
           cp -a ./build-lv2-ind-ci/airwindows-individual.lv2 ./artifact/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           path: artifact
           name: lv2-individual-macos

--- a/.github/workflows/build-lv2-individual.yml
+++ b/.github/workflows/build-lv2-individual.yml
@@ -1,8 +1,11 @@
 name: Build LV2 Individual
 on:
   push:
-    branches:
-      - test-lv2-individual-ci
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -353,3 +356,61 @@ jobs:
         with:
           path: artifact
           name: lv2-individual-macos
+
+  release_lv2_individual:
+    name: Release LV2 Individual Bundles
+    runs-on: ubuntu-latest
+    needs:
+      - build_lv2_individual_linux
+      - build_lv2_individual_windows
+      - build_lv2_individual_macos
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: lv2-individual-linux
+          path: ./release-assets/linux
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: lv2-individual-windows
+          path: ./release-assets/windows
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: lv2-individual-macos
+          path: ./release-assets/macos
+
+      - name: Package release assets
+        run: |
+          set -euo pipefail
+          tag_name="${GITHUB_REF_NAME}"
+          mkdir -p ./release-dist
+
+          tar -C ./release-assets/linux -czf "./release-dist/airwindows-individual-lv2-${tag_name}-linux-x86_64.tar.gz" airwindows-individual.lv2
+          tar -C ./release-assets/macos -czf "./release-dist/airwindows-individual-lv2-${tag_name}-macos-arm64.tar.gz" airwindows-individual.lv2
+
+          pushd ./release-assets/windows >/dev/null
+          zip -r "../../release-dist/airwindows-individual-lv2-${tag_name}-windows-x86_64.zip" airwindows-individual.lv2
+          popd >/dev/null
+
+          ls -lh ./release-dist
+
+      - name: Create or update release and upload assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag_name="${GITHUB_REF_NAME}"
+
+          if ! gh release view "$tag_name" >/dev/null 2>&1; then
+            gh release create "$tag_name" \
+              --title "$tag_name" \
+              --notes "Automated LV2 individual bundle release for $tag_name"
+          fi
+
+          gh release upload "$tag_name" ./release-dist/* --clobber

--- a/.github/workflows/build-lv2-individual.yml
+++ b/.github/workflows/build-lv2-individual.yml
@@ -20,6 +20,12 @@ jobs:
       options: --user root
 
     steps:
+      - name: Install Git for checkout
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y git
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-lv2-individual.yml
+++ b/.github/workflows/build-lv2-individual.yml
@@ -49,8 +49,13 @@ jobs:
         run: |
           find ./build-lv2-ind-ci/airwindows-individual.lv2 -maxdepth 1 -type f -print
 
+      - name: Stage LV2 artifact
+        run: |
+          mkdir -p ./artifact
+          cp -a ./build-lv2-ind-ci/airwindows-individual.lv2 ./artifact/
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          path: build-lv2-ind-ci/airwindows-individual.lv2
+          path: artifact
           name: lv2-individual-linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(BUILD_JUCE_PLUGIN "Build a JUCE plugin" OFF)
 option(USE_JUCE_PROGRAMS "Add effects as presets when building juce plugin" OFF)
 option(BUILD_RACK_PLUGIN "Build a VCV Rack plugin" OFF)
 option(COPY_PLUGIN_AFTER_BUILD "Copy plugin after build" OFF)
+option(BUILD_LV2_INDIVIDUAL "Build individual per-effect LV2 plugins (one descriptor per effect)" OFF)
 
 math(EXPR AW_BITNESS "${CMAKE_SIZEOF_VOID_P} * 8" OUTPUT_FORMAT DECIMAL)
 message(STATUS "Performing ${AW_BITNESS}-bit build")
@@ -102,4 +103,8 @@ if (${BUILD_JUCE_PLUGIN})
     cmrc_add_resource_library(awconsolidated_resources ${AWCON_RESOURCES_GLOB})
 
     add_subdirectory(src-juce)
+endif()
+
+if (${BUILD_LV2_INDIVIDUAL})
+    add_subdirectory(src-lv2)
 endif()

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ cmake -Bignore/daw-plugin -DBUILD_JUCE_PLUGIN=TRUE -DCMAKE_BUILD_TYPE=Release
 cmake --build ignore/daw-plugin --target awcons-products
 ```
 
+## LV2 Separate Plugins Bundle
+
+By default, Juce creates a single LV2 plugin from which the individual effects can
+be selected. You can alternatively build a single LV2 bundle with the effects as
+separate plugins.
+
+### Build
+
+```bash
+cmake -Bbuild-lv2-ind -DBUILD_LV2_INDIVIDUAL=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build-lv2-ind --parallel
+```
+
+The plugin will be built in `build-lv2-ind/airwindows-individual.lv2/`.
+
+
 ## Updating the airwindows sub-library
 
 To update the airwindows library

--- a/src-lv2/CMakeLists.txt
+++ b/src-lv2/CMakeLists.txt
@@ -1,0 +1,81 @@
+# vi:set sw=2 et:
+project(airwindows-individual-lv2)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LV2 REQUIRED lv2)
+
+set(AW_LV2_BUNDLE_DIR "${CMAKE_BINARY_DIR}/airwindows-individual.lv2")
+file(MAKE_DIRECTORY "${AW_LV2_BUNDLE_DIR}")
+
+# ------------------------------------------------------------------
+# TTL generator (native executable — always built for the host)
+# ------------------------------------------------------------------
+add_executable(airwindows-ttl-gen generate-ttl.cpp)
+target_link_libraries(airwindows-ttl-gen PRIVATE airwin-registry)
+
+if (NOT MSVC)
+  target_compile_options(airwindows-ttl-gen PRIVATE
+    -Wno-unused-function
+    -Wno-unused-value
+    -Wno-unused-but-set-variable
+    -Wno-multichar
+  )
+endif()
+
+# ------------------------------------------------------------------
+# Run the generator at build time to produce the TTL bundle files
+# ------------------------------------------------------------------
+add_custom_command(
+  OUTPUT
+    "${AW_LV2_BUNDLE_DIR}/manifest.ttl"
+    "${AW_LV2_BUNDLE_DIR}/airwindows-individual.ttl"
+  COMMAND "$<TARGET_FILE:airwindows-ttl-gen>" "${AW_LV2_BUNDLE_DIR}"
+  DEPENDS airwindows-ttl-gen
+  COMMENT "Generating airwindows-individual LV2 TTL files"
+  VERBATIM
+)
+
+add_custom_target(airwindows-individual-ttl
+  DEPENDS
+    "${AW_LV2_BUNDLE_DIR}/manifest.ttl"
+    "${AW_LV2_BUNDLE_DIR}/airwindows-individual.ttl"
+)
+
+# ------------------------------------------------------------------
+# LV2 plugin shared library
+# ------------------------------------------------------------------
+add_library(airwindows-individual MODULE plugin.cpp)
+
+target_include_directories(airwindows-individual PRIVATE ${LV2_INCLUDE_DIRS})
+target_link_libraries(airwindows-individual PRIVATE airwin-registry)
+
+if (NOT MSVC)
+  target_compile_options(airwindows-individual PRIVATE
+    -Wno-unused-function
+    -Wno-unused-value
+    -Wno-unused-but-set-variable
+    -Wno-multichar
+  )
+endif()
+
+# LV2 .so names use no lib-prefix and no version suffix
+set_target_properties(airwindows-individual PROPERTIES
+  PREFIX  ""
+  SUFFIX  ".so"
+  LIBRARY_OUTPUT_DIRECTORY "${AW_LV2_BUNDLE_DIR}"
+)
+
+# ------------------------------------------------------------------
+# Top-level convenience target: build the complete bundle
+# ------------------------------------------------------------------
+add_custom_target(airwindows-individual-lv2 ALL
+  DEPENDS airwindows-individual airwindows-individual-ttl
+)
+
+# ------------------------------------------------------------------
+# Install: copy the bundle to the standard LV2 path
+# ------------------------------------------------------------------
+install(
+  DIRECTORY "${AW_LV2_BUNDLE_DIR}"
+  DESTINATION "$ENV{HOME}/.lv2"
+)

--- a/src-lv2/CMakeLists.txt
+++ b/src-lv2/CMakeLists.txt
@@ -59,6 +59,14 @@ add_library(airwindows-individual MODULE plugin.cpp)
 target_include_directories(airwindows-individual PRIVATE ${LV2_INCLUDE_DIRS})
 target_link_libraries(airwindows-individual PRIVATE airwin-registry)
 
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_link_options(airwindows-individual PRIVATE -static-libstdc++ -static-libgcc)
+  else()
+    message(STATUS "Linux LV2 builds use static libstdc++/libgcc when compiling with GCC; leaving the runtime dynamic for ${CMAKE_CXX_COMPILER_ID}")
+  endif()
+endif()
+
 if (NOT MSVC)
   target_compile_options(airwindows-individual PRIVATE
     -Wno-unused-function

--- a/src-lv2/CMakeLists.txt
+++ b/src-lv2/CMakeLists.txt
@@ -59,11 +59,11 @@ add_library(airwindows-individual MODULE plugin.cpp)
 target_include_directories(airwindows-individual PRIVATE ${LV2_INCLUDE_DIRS})
 target_link_libraries(airwindows-individual PRIVATE airwin-registry)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR WIN32)
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_link_options(airwindows-individual PRIVATE -static-libstdc++ -static-libgcc)
   else()
-    message(STATUS "Linux LV2 builds use static libstdc++/libgcc when compiling with GCC; leaving the runtime dynamic for ${CMAKE_CXX_COMPILER_ID}")
+    message(STATUS "LV2 builds use static libstdc++/libgcc when compiling with GCC; leaving the runtime dynamic for ${CMAKE_CXX_COMPILER_ID}")
   endif()
 endif()
 
@@ -76,10 +76,15 @@ if (NOT MSVC)
   )
 endif()
 
-# LV2 .so names use no lib-prefix and no version suffix
+# LV2 binaries use no lib-prefix and no version suffix; extension is platform-specific
+if (WIN32)
+  set(_lv2_binary_suffix ".dll")
+else()
+  set(_lv2_binary_suffix ".so")
+endif()
 set_target_properties(airwindows-individual PROPERTIES
   PREFIX  ""
-  SUFFIX  ".so"
+  SUFFIX  "${_lv2_binary_suffix}"
   LIBRARY_OUTPUT_DIRECTORY "${AW_LV2_BUNDLE_DIR}"
 )
 

--- a/src-lv2/CMakeLists.txt
+++ b/src-lv2/CMakeLists.txt
@@ -1,8 +1,12 @@
 # vi:set sw=2 et:
-project(airwindows-individual-lv2)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LV2 REQUIRED lv2)
+
+set(AW_LV2_VERSION_MAJOR "${Airwin2Rack_VERSION_MAJOR}")
+set(AW_LV2_VERSION_MINOR "${Airwin2Rack_VERSION_MINOR}")
+set(AW_LV2_VERSION_MICRO "${Airwin2Rack_VERSION_PATCH}")
+set(AW_LV2_VERSION_TEXT "${Airwin2Rack_VERSION}")
 
 set(AW_LV2_BUNDLE_DIR "${CMAKE_BINARY_DIR}/airwindows-individual.lv2")
 file(MAKE_DIRECTORY "${AW_LV2_BUNDLE_DIR}")
@@ -12,6 +16,12 @@ file(MAKE_DIRECTORY "${AW_LV2_BUNDLE_DIR}")
 # ------------------------------------------------------------------
 add_executable(airwindows-ttl-gen generate-ttl.cpp)
 target_link_libraries(airwindows-ttl-gen PRIVATE airwin-registry)
+target_compile_definitions(airwindows-ttl-gen PRIVATE
+  AW_LV2_VERSION_MAJOR=${AW_LV2_VERSION_MAJOR}
+  AW_LV2_VERSION_MINOR=${AW_LV2_VERSION_MINOR}
+  AW_LV2_VERSION_MICRO=${AW_LV2_VERSION_MICRO}
+  AW_LV2_VERSION_TEXT="${AW_LV2_VERSION_TEXT}"
+)
 
 if (NOT MSVC)
   target_compile_options(airwindows-ttl-gen PRIVATE

--- a/src-lv2/generate-ttl.cpp
+++ b/src-lv2/generate-ttl.cpp
@@ -1,0 +1,262 @@
+/*
+ * generate-ttl — standalone executable that writes the LV2 bundle TTL files
+ * for airwindows-individual.
+ *
+ * Usage: generate-ttl <bundle-dir>
+ *
+ * Outputs:
+ *   <bundle-dir>/manifest.ttl              — lists all plugin URIs
+ *   <bundle-dir>/airwindows-individual.ttl — full plugin descriptions
+ *
+ * The binary links against airwin-registry, so the registry static
+ * initializers in ModuleAdd.h populate AirwinRegistry::registry before
+ * main() runs.
+ *
+ * This source released under the MIT License.
+ */
+
+#include "AirwinRegistry.h"
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <set>
+#include <cctype>
+#include <memory>
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Produce a valid LV2 port symbol (C-identifier-like) from a human name.
+static std::string makeSymbol(const std::string& name)
+{
+    std::string sym;
+    for (unsigned char c : name)
+    {
+        if (std::isalnum(c))
+            sym += static_cast<char>(std::tolower(c));
+        else if (c == ' ' || c == '-' || c == '_' || c == '.')
+            sym += '_';
+        // other punctuation / special chars dropped
+    }
+    // Collapse repeated underscores
+    std::string out;
+    bool lastWasUnderscore = false;
+    for (char c : sym)
+    {
+        if (c == '_' && lastWasUnderscore) continue;
+        lastWasUnderscore = (c == '_');
+        out += c;
+    }
+    // Strip leading/trailing underscores
+    while (!out.empty() && out.front() == '_') out.erase(out.begin());
+    while (!out.empty() && out.back()  == '_') out.pop_back();
+    // A symbol must not start with a digit
+    if (!out.empty() && std::isdigit(static_cast<unsigned char>(out[0])))
+        out = "p" + out;
+    if (out.empty()) out = "ctrl";
+    return out;
+}
+
+// Escape a string for use inside a Turtle string literal ("...").
+static std::string ttlEscape(const std::string& s)
+{
+    std::string out;
+    out.reserve(s.size());
+    for (unsigned char c : s)
+    {
+        switch (c)
+        {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n";  break;
+            case '\r': /* skip */     break;
+            case '\t': out += " ";    break;
+            default:
+                if (c < 0x20) break; // skip other control chars
+                out += static_cast<char>(c);
+        }
+    }
+    return out;
+}
+
+// Map an Airwindows category string to a suitable lv2: plugin type URI.
+static const char* categoryToLv2Type(const std::string& cat)
+{
+    if (cat == "Reverb" || cat == "Ambience")                     return "lv2:ReverbPlugin";
+    if (cat == "Dynamics")                                        return "lv2:CompressorPlugin";
+    if (cat == "Clipping")                                        return "lv2:LimiterPlugin";
+    if (cat == "Distortion" || cat == "Lo-Fi" || cat == "Noise") return "lv2:DistortionPlugin";
+    if (cat == "Filter" || cat == "Biquads"
+        || cat == "XYZ Filters" || cat == "Bass")                 return "lv2:FilterPlugin";
+    if (cat == "Brightness" || cat == "Tone Color")               return "lv2:EQPlugin";
+    if (cat == "Saturation" || cat == "Tape")                     return "lv2:WaveshaperPlugin";
+    if (cat == "Stereo")                                          return "lv2:SpatialPlugin";
+    if (cat == "Amp Sims")                                        return "lv2:SimulatorPlugin";
+    if (cat == "Consoles" || cat == "Utility" || cat == "Dithers") return "lv2:UtilityPlugin";
+    // Subtlety, Effects, Unclassified, etc.
+    return "lv2:FilterPlugin";
+}
+
+// ---------------------------------------------------------------------------
+// TTL generation
+// ---------------------------------------------------------------------------
+
+static bool writeManifest(const std::string& bundleDir,
+                          const std::vector<AirwinRegistry::awReg>& registry)
+{
+    std::ofstream f(bundleDir + "manifest.ttl");
+    if (!f) { std::cerr << "Cannot write manifest.ttl\n"; return false; }
+
+    f << "@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .\n";
+    f << "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\n";
+
+    for (const auto& r : registry)
+    {
+        f << "<https://airwindows.com/lv2/" << r.name << ">\n";
+        f << "    a lv2:Plugin ;\n";
+        f << "    lv2:binary <airwindows-individual.so> ;\n";
+        f << "    rdfs:seeAlso <airwindows-individual.ttl> .\n\n";
+    }
+    return true;
+}
+
+static bool writePluginTtl(const std::string& bundleDir,
+                           const std::vector<AirwinRegistry::awReg>& registry)
+{
+    std::ofstream f(bundleDir + "airwindows-individual.ttl");
+    if (!f) { std::cerr << "Cannot write airwindows-individual.ttl\n"; return false; }
+
+    f << "@prefix doap: <http://usefulinc.com/ns/doap#> .\n";
+    f << "@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .\n";
+    f << "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\n";
+
+    for (const auto& r : registry)
+    {
+        // Instantiate the effect to read parameter names and default values.
+        auto fx = r.generator();
+        fx->setSampleRate(44100.0f);
+
+        // Collect parameter symbols, deduplicating within this plugin.
+        std::set<std::string> usedSymbols;
+        auto uniqueSymbol = [&](const std::string& base) -> std::string
+        {
+            std::string sym = base;
+            int suffix = 2;
+            while (usedSymbols.count(sym))
+                sym = base + "_" + std::to_string(suffix++);
+            usedSymbols.insert(sym);
+            return sym;
+        };
+
+        // ---- Plugin header ------------------------------------------------
+        f << "<https://airwindows.com/lv2/" << r.name << ">\n";
+        f << "    a lv2:Plugin, " << categoryToLv2Type(r.category) << " ;\n";
+        f << "    doap:name \"" << ttlEscape(r.name) << "\" ;\n";
+        f << "    doap:license <https://opensource.org/licenses/MIT> ;\n";
+        if (!r.whatText.empty())
+            f << "    rdfs:comment \"" << ttlEscape(r.whatText) << "\" ;\n";
+        f << "    lv2:minorVersion 0 ;\n";
+        f << "    lv2:microVersion 0 ;\n";
+
+        // ---- Port list ----------------------------------------------------
+        // Helper lambdas that emit port separators correctly.
+        int portEmitted = 0;
+        int totalPorts  = 4 + r.nParams;
+
+        auto beginPort = [&]()
+        {
+            if (portEmitted == 0) f << "    lv2:port [\n";
+            else                  f << "    ] , [\n";
+            ++portEmitted;
+        };
+        auto endLastPort = [&]()
+        {
+            f << "    ] .\n\n";
+        };
+
+        // Audio in L
+        beginPort();
+        f << "        a lv2:AudioPort, lv2:InputPort ;\n";
+        f << "        lv2:index 0 ;\n";
+        f << "        lv2:symbol \"in_l\" ;\n";
+        f << "        lv2:name \"In L\"\n";
+
+        // Audio in R
+        beginPort();
+        f << "        a lv2:AudioPort, lv2:InputPort ;\n";
+        f << "        lv2:index 1 ;\n";
+        f << "        lv2:symbol \"in_r\" ;\n";
+        f << "        lv2:name \"In R\"\n";
+
+        // Audio out L
+        beginPort();
+        f << "        a lv2:AudioPort, lv2:OutputPort ;\n";
+        f << "        lv2:index 2 ;\n";
+        f << "        lv2:symbol \"out_l\" ;\n";
+        f << "        lv2:name \"Out L\"\n";
+
+        // Audio out R
+        beginPort();
+        f << "        a lv2:AudioPort, lv2:OutputPort ;\n";
+        f << "        lv2:index 3 ;\n";
+        f << "        lv2:symbol \"out_r\" ;\n";
+        f << "        lv2:name \"Out R\"\n";
+
+        // Control ports
+        for (int p = 0; p < r.nParams; ++p)
+        {
+            char nameBuf[kVstMaxParamStrLen];
+            nameBuf[0] = '\0';
+            fx->getParameterName(p, nameBuf);
+            std::string pname(nameBuf);
+
+            std::string sym = uniqueSymbol(
+                makeSymbol(pname.empty() ? "ctrl" : pname));
+
+            float def = fx->getParameter(p);
+
+            beginPort();
+            f << "        a lv2:ControlPort, lv2:InputPort ;\n";
+            f << "        lv2:index " << (4 + p) << " ;\n";
+            f << "        lv2:symbol \"" << sym << "\" ;\n";
+            f << "        lv2:name \"" << ttlEscape(pname) << "\" ;\n";
+            f << "        lv2:default " << def << " ;\n";
+            f << "        lv2:minimum 0.0 ;\n";
+            f << "        lv2:maximum 1.0\n";
+        }
+
+        (void)totalPorts; // used only for the conceptual count
+        endLastPort();
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+    if (argc < 2)
+    {
+        std::cerr << "Usage: " << argv[0] << " <bundle-directory>\n";
+        return 1;
+    }
+
+    std::string bundleDir = argv[1];
+    if (bundleDir.back() != '/') bundleDir += '/';
+
+    // registry is populated by static initializers in ModuleAdd.h
+    // before main() is entered; no explicit init call required.
+    AirwinConsolidatedBase::defaultSampleRate = 44100.0f;
+
+    const auto& registry = AirwinRegistry::registry;
+
+    if (!writeManifest(bundleDir, registry))   return 1;
+    if (!writePluginTtl(bundleDir, registry))  return 1;
+
+    std::cout << "Wrote " << registry.size()
+              << " plugin descriptors to " << bundleDir << "\n";
+    return 0;
+}

--- a/src-lv2/generate-ttl.cpp
+++ b/src-lv2/generate-ttl.cpp
@@ -170,7 +170,7 @@ static bool writePluginTtl(const std::string& bundleDir,
         // ---- Plugin header ------------------------------------------------
         f << "<https://airwindows.com/lv2/" << r.name << ">\n";
         f << "    a lv2:Plugin, " << categoryToLv2Type(r.category) << " ;\n";
-        f << "    doap:name \"" << ttlEscape(r.name) << "\" ;\n";
+        f << "    doap:name \"AW_" << ttlEscape(r.name) << "\" ;\n";
         f << "    doap:license <https://opensource.org/licenses/MIT> ;\n";
         f << "    doap:maintainer [\n";
         f << "        a foaf:Person ;\n";

--- a/src-lv2/generate-ttl.cpp
+++ b/src-lv2/generate-ttl.cpp
@@ -128,11 +128,19 @@ static bool writeManifest(const std::string& bundleDir,
     f << "@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .\n";
     f << "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\n";
 
+#if defined(_WIN32)
+    const char* lv2BinaryExt = ".dll";
+#elif defined(__APPLE__)
+    const char* lv2BinaryExt = ".dylib";
+#else
+    const char* lv2BinaryExt = ".so";
+#endif
+
     for (const auto& r : registry)
     {
         f << "<https://airwindows.com/lv2/" << r.name << ">\n";
         f << "    a lv2:Plugin ;\n";
-        f << "    lv2:binary <airwindows-individual.so> ;\n";
+        f << "    lv2:binary <airwindows-individual" << lv2BinaryExt << "> ;\n";
         f << "    rdfs:seeAlso <airwindows-individual.ttl> .\n\n";
     }
     return true;

--- a/src-lv2/generate-ttl.cpp
+++ b/src-lv2/generate-ttl.cpp
@@ -24,6 +24,22 @@
 #include <cctype>
 #include <memory>
 
+#ifndef AW_LV2_VERSION_MAJOR
+#define AW_LV2_VERSION_MAJOR 0
+#endif
+
+#ifndef AW_LV2_VERSION_MINOR
+#define AW_LV2_VERSION_MINOR 0
+#endif
+
+#ifndef AW_LV2_VERSION_MICRO
+#define AW_LV2_VERSION_MICRO 0
+#endif
+
+#ifndef AW_LV2_VERSION_TEXT
+#define AW_LV2_VERSION_TEXT "0.0.0"
+#endif
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -129,6 +145,7 @@ static bool writePluginTtl(const std::string& bundleDir,
     if (!f) { std::cerr << "Cannot write airwindows-individual.ttl\n"; return false; }
 
     f << "@prefix doap: <http://usefulinc.com/ns/doap#> .\n";
+    f << "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n";
     f << "@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .\n";
     f << "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\n";
 
@@ -155,10 +172,20 @@ static bool writePluginTtl(const std::string& bundleDir,
         f << "    a lv2:Plugin, " << categoryToLv2Type(r.category) << " ;\n";
         f << "    doap:name \"" << ttlEscape(r.name) << "\" ;\n";
         f << "    doap:license <https://opensource.org/licenses/MIT> ;\n";
+        f << "    doap:maintainer [\n";
+        f << "        a foaf:Person ;\n";
+        f << "        foaf:name \"Airwindows\" ;\n";
+        f << "        foaf:homepage <https://airwindows.com/> ;\n";
+        f << "        foaf:mbox <> ;\n";
+        f << "    ] ;\n";
+        f << "    doap:release [\n";
+        f << "        a doap:Version ;\n";
+        f << "        doap:revision \"" << AW_LV2_VERSION_TEXT << "\" ;\n";
+        f << "    ] ;\n";
         if (!r.whatText.empty())
             f << "    rdfs:comment \"" << ttlEscape(r.whatText) << "\" ;\n";
-        f << "    lv2:minorVersion 0 ;\n";
-        f << "    lv2:microVersion 0 ;\n";
+        f << "    lv2:minorVersion " << AW_LV2_VERSION_MINOR << " ;\n";
+        f << "    lv2:microVersion " << AW_LV2_VERSION_MICRO << " ;\n";
 
         // ---- Port list ----------------------------------------------------
         // Helper lambdas that emit port separators correctly.

--- a/src-lv2/plugin.cpp
+++ b/src-lv2/plugin.cpp
@@ -1,0 +1,219 @@
+/*
+ * airwindows-individual - native LV2 wrapper for the Airwindows effect suite.
+ *
+ * Exposes one LV2 plugin descriptor per effect from a single shared binary,
+ * with exact per-effect control ports matching each effect's parameter
+ * count.  No JUCE involvement; links only against airwin-registry.
+ *
+ * Port layout (same for every effect):
+ *   0   - Audio Input  L  (lv2:AudioPort lv2:InputPort)
+ *   1   - Audio Input  R  (lv2:AudioPort lv2:InputPort)
+ *   2   - Audio Output L  (lv2:AudioPort lv2:OutputPort)
+ *   3   - Audio Output R  (lv2:AudioPort lv2:OutputPort)
+ *   4.. - Control Inputs  (lv2:ControlPort lv2:InputPort, nParams of them)
+ *
+ * This source released under the MIT License.
+ */
+
+#include <lv2/core/lv2.h>
+#include "AirwinRegistry.h"
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <mutex>
+#include <cstdint>
+
+// ---------------------------------------------------------------------------
+// Port index constants
+// ---------------------------------------------------------------------------
+static constexpr uint32_t PORT_AUDIO_IN_L  = 0;
+static constexpr uint32_t PORT_AUDIO_IN_R  = 1;
+static constexpr uint32_t PORT_AUDIO_OUT_L = 2;
+static constexpr uint32_t PORT_AUDIO_OUT_R = 3;
+static constexpr uint32_t PORT_CTRL_BASE   = 4;
+
+// ---------------------------------------------------------------------------
+// Forward declarations of LV2 callback functions
+// ---------------------------------------------------------------------------
+static LV2_Handle  aw_instantiate    (const LV2_Descriptor*, double, const char*, const LV2_Feature* const*);
+static void        aw_connect_port   (LV2_Handle, uint32_t, void*);
+static void        aw_activate       (LV2_Handle);
+static void        aw_run            (LV2_Handle, uint32_t);
+static void        aw_deactivate     (LV2_Handle);
+static void        aw_cleanup        (LV2_Handle);
+static const void* aw_extension_data (const char*);
+
+// ---------------------------------------------------------------------------
+// Per-descriptor metadata
+//
+// One .so binary, hundreds of plugins.
+//
+// Each effect gets a static LV2_Descriptor that the host sees as a separate
+// plugin to load. The trick: AwDescriptorEntry embeds the descriptor as its
+// FIRST MEMBER, so we can cast an LV2_Descriptor* directly back to
+// AwDescriptorEntry* to recover the registryIndex without a lookup table.
+//
+// HOW IT WORKS:
+// 1. Host loads the descriptor for eg. plugin #5 (Galactic)
+// 2. lv2_descriptor(5) returns &g_descriptors[5].descriptor
+// 3. Host calls instantiate(&descriptor, ...)
+// 4. We cast: entry = (AwDescriptorEntry*)descriptor
+// 5. Look up: reg = registry[entry->registryIndex]  (which is 5)
+// 6. Call: effect = reg.generator()  (creates Galactic object)
+// 7. Return: handle pointing to AwLv2Instance with that Galactic inside
+//
+// When host simultaneously loads plugin #0 (ADClip7):
+// - Separate entry, separate registryIndex, separate effect object (ADClip7)
+// - Same .so, totally independent processing chains
+// - Each has its own handle, state, and effect instance
+// ---------------------------------------------------------------------------
+struct AwDescriptorEntry {
+    LV2_Descriptor descriptor;   // FIRST MEMBER — enables container_of cast
+    int            registryIndex; // which effect in AirwinRegistry
+    std::string    uriStorage;   // owns the heap memory for descriptor.URI
+};
+
+// ---------------------------------------------------------------------------
+// Per-instance runtime data
+// ---------------------------------------------------------------------------
+struct AwLv2Instance {
+    int    registryIndex;
+    int    nParams;
+    std::unique_ptr<AirwinConsolidatedBase> effect;
+
+    // Pointers set by connect_port; may be null until first block
+    float* audioInL  = nullptr;
+    float* audioInR  = nullptr;
+    float* audioOutL = nullptr;
+    float* audioOutR = nullptr;
+
+    // One pointer per control parameter; null means not yet connected
+    std::vector<float*> ctrlPorts;
+};
+
+// ---------------------------------------------------------------------------
+// Global descriptor table (lazily built once)
+// ---------------------------------------------------------------------------
+static std::vector<AwDescriptorEntry> g_descriptors;
+static std::once_flag                 g_initFlag;
+
+static void buildDescriptors()
+{
+    // Set a sensible default for effects that read it before their first
+    // instantiation (e.g. in constructor-side assertions).
+    AirwinConsolidatedBase::defaultSampleRate = 44100.0f;
+
+    // Size the vector once so entries never move after this point.
+    // The uriStorage.c_str() pointer must remain stable for the lifetime
+    // of the process — this single resize + in-place fill guarantees that.
+    g_descriptors.resize(AirwinRegistry::registry.size());
+
+    for (size_t i = 0; i < AirwinRegistry::registry.size(); ++i)
+    {
+        const auto& reg = AirwinRegistry::registry[i];
+        auto&       e   = g_descriptors[i];
+
+        e.registryIndex = static_cast<int>(i);
+        e.uriStorage    = "https://airwindows.com/lv2/" + reg.name;
+
+        e.descriptor.URI            = e.uriStorage.c_str();
+        e.descriptor.instantiate    = aw_instantiate;
+        e.descriptor.connect_port   = aw_connect_port;
+        e.descriptor.activate       = aw_activate;
+        e.descriptor.run            = aw_run;
+        e.descriptor.deactivate     = aw_deactivate;
+        e.descriptor.cleanup        = aw_cleanup;
+        e.descriptor.extension_data = aw_extension_data;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LV2 callbacks
+// ---------------------------------------------------------------------------
+static LV2_Handle aw_instantiate(
+    const LV2_Descriptor*       descriptor,
+    double                      sample_rate,
+    const char*                 /*bundle_path*/,
+    const LV2_Feature* const*   /*features*/)
+{
+    // The host is passing us a descriptor for ONE specific effect (e.g., Galactic).
+    // We need to figure out which effect it is and instantiate the right one.
+    //
+    // The descriptor is actually the first member of AwDescriptorEntry (our struct).
+    // By casting it, we recover the original entry and its registryIndex.
+    // Then we use that index to instantiate the exact right effect.
+    const auto* entry = reinterpret_cast<const AwDescriptorEntry*>(descriptor);
+    const auto& reg   = AirwinRegistry::registry[entry->registryIndex];
+
+    // Now create an instance of THIS specific effect (Galactic, ADClip7, etc.)
+    auto* inst       = new AwLv2Instance();
+    inst->registryIndex = entry->registryIndex;
+    inst->nParams       = reg.nParams;
+    inst->effect        = reg.generator();  // <-- Create Galactic, or Baxandall, or...
+    inst->effect->setSampleRate(static_cast<float>(sample_rate));
+    inst->ctrlPorts.assign(reg.nParams, nullptr);
+
+    // Each handle is independent. If the host loads Galactic AND Baxandall
+    // at the same time, they'll each get their own handle with their own effect instance.
+    return inst;
+}
+
+static void aw_connect_port(LV2_Handle handle, uint32_t port, void* data)
+{
+    auto* inst = static_cast<AwLv2Instance*>(handle);
+    switch (port)
+    {
+        case PORT_AUDIO_IN_L:  inst->audioInL  = static_cast<float*>(data); return;
+        case PORT_AUDIO_IN_R:  inst->audioInR  = static_cast<float*>(data); return;
+        case PORT_AUDIO_OUT_L: inst->audioOutL = static_cast<float*>(data); return;
+        case PORT_AUDIO_OUT_R: inst->audioOutR = static_cast<float*>(data); return;
+        default: break;
+    }
+    int p = static_cast<int>(port) - static_cast<int>(PORT_CTRL_BASE);
+    if (p >= 0 && p < inst->nParams)
+        inst->ctrlPorts[p] = static_cast<float*>(data);
+}
+
+static void aw_activate(LV2_Handle /*handle*/) {}
+
+static void aw_run(LV2_Handle handle, uint32_t sample_count)
+{
+    auto* inst = static_cast<AwLv2Instance*>(handle);
+    if (!inst->effect
+        || !inst->audioInL || !inst->audioInR
+        || !inst->audioOutL || !inst->audioOutR)
+        return;
+
+    // Update parameters from the host
+    for (int p = 0; p < inst->nParams; ++p)
+    {
+        if (inst->ctrlPorts[p])
+            inst->effect->setParameter(p, *inst->ctrlPorts[p]);
+    }
+
+    // Process audio using instance's effect object
+    float* inputs[2]  = { inst->audioInL,  inst->audioInR  };
+    float* outputs[2] = { inst->audioOutL, inst->audioOutR };
+    inst->effect->processReplacing(inputs, outputs, static_cast<int32_t>(sample_count));
+}
+
+static void aw_deactivate(LV2_Handle /*handle*/) {}
+
+static void aw_cleanup(LV2_Handle handle)
+{
+    delete static_cast<AwLv2Instance*>(handle);
+}
+
+static const void* aw_extension_data(const char* /*uri*/) { return nullptr; }
+
+// ---------------------------------------------------------------------------
+// LV2 entry point
+// ---------------------------------------------------------------------------
+LV2_SYMBOL_EXPORT const LV2_Descriptor* lv2_descriptor(uint32_t index)
+{
+    std::call_once(g_initFlag, buildDescriptors);
+    if (index >= static_cast<uint32_t>(g_descriptors.size()))
+        return nullptr;
+    return &g_descriptors[index].descriptor;
+}


### PR DESCRIPTION
Reopening https://github.com/baconpaul/airwin2rack/pull/222, which I closed by mistake.

This builds the plugins for LV2, as a bundle with one plugin but separate descriptors for each effect (as opposed to one plugin / one descriptor that can run any of the ~400 airwindows effects). This makes it possible to "Favourite" effects, and means the plugins show up with the effect name rather than just "Airwindows Consolidated". For me, this seems like a preferable way to do it.

It's essentially two files:

* `generate-ttl.cpp` - a simple "script" that goes through AirwinRegistry and spits out .ttl metadata files at build time
* `plugin.cpp` - LV2 binary that finds the AirwinRegistry entry corresponding to the LV2 plugin descriptor and wraps it for LV2

It also now has a git workflow that makes releases for Linux / Windows / Mac. I can only test easily in Linux, but in theory the others should work. I also made a little [smoke test](https://github.com/Joeboy/lv2-smoketest) utility and added it into the CI. After that bit of yak shaving I can point people at the [release](https://github.com/Joeboy/airwin2rack/releases) for testing purposes.

I suggest it can sit in my branch for now until I and hopefully some other people have tested it a bit more.