### PR TITLE
LICENSE.md: Update copyright years

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2019-2020, Paul Walker
+Copyright 2019-2026, Paul Walker
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Hello,
I am considering making a [Debian package](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1140409) for airwindows-consolidated. Through doing that work I noticed these copyright years in the license file could probably be updated for accuracy.